### PR TITLE
update cci reference to proper formatting

### DIFF
--- a/rules/permanent/audit_enforce_dual_auth.yaml
+++ b/rules/permanent/audit_enforce_dual_auth.yaml
@@ -10,7 +10,8 @@ references:
   cce:
     - CCE-84906-7
   cci:
-    - CCI-000366, CCI-001896
+    - CCI-000366
+    - CCI-001896
   800-53r4:
     - CM-6(b)
     - AU-9(5)


### PR DESCRIPTION
The CCI reference should be on it's own line, otherwise automatic parsing can fail.