### PR TITLE
Removed duplicate title, description & authors rows

### DIFF
--- a/baselines/all_rules.yaml
+++ b/baselines/all_rules.yaml
@@ -6,13 +6,6 @@ authors: |
   |Bob Gendler|National Institute of Standards and Technology
   |Dan Brodjieski|National Aeronautics and Space Administration
   |Allen Golbig|Jamf
-  |===  
-title: "macOS 12.0: Security Configuration - all_rules"
-description: |
-  This guide describes the actions to take when securing a macOS 12.0 system against the all_rules baseline.
-authors: |
-  |===
-  |Name|Organization
   |===
 profile:
   - section: "authentication"

--- a/baselines/cnssi-1253.yaml
+++ b/baselines/cnssi-1253.yaml
@@ -7,13 +7,6 @@ authors: |
   |Ekkehard Koch|
   |Bob Gendler|National Institute of Standards and Technology
   |===
-title: "macOS 12.0: Security Configuration - cnssi-1253"
-description: |
-  This guide describes the actions to take when securing a macOS 12.0 system against the cnssi-1253 baseline.
-authors: |
-  |===
-  |Name|Organization
-  |===
 profile:
   - section: "authentication"
     rules:


### PR DESCRIPTION
Two of the baselines have duplicate title, description and authors rows. Please review for any inaccuracies. 