### PR TITLE
Update additional docs file, link to Apple's 2022 Apple Platform Deployment Guide

### DIFF
--- a/templates/adoc_additional_docs.adoc
+++ b/templates/adoc_additional_docs.adoc
@@ -46,8 +46,7 @@ ASSOCIATED DOCUMENTS
 |Document Number or Descriptor
 |Document Title
 |link:https://support.apple.com/guide/security/welcome/web[Apple Platform Security Guide]|_Apple Platform Security_
-|link:https://support.apple.com/guide/deployment-reference-macos/welcome/web[Deployment Reference for Mac]|_Deployment Reference_
-|link:https://support.apple.com/guide/mdm/welcome/web[Mobile Device Management Settings]|_Mobile Device Management Settings_
+|link:https://support.apple.com/guide/deployment/welcome/web[Apple Platform Deployment]|_Apple Platform Deployment_
 |link:https://developer.apple.com/documentation/devicemanagement/profile-specific_payload_keys[Profile-Specific Payload Keys]|_Profile-Specific Payload Keys_
 |link:https://support.apple.com/guide/sccc/welcome/web[Security Certifications and Compliance Center]|_Security Certifications and Compliance Center_
 |===


### PR DESCRIPTION
Previous links referencing Apple Mac Deployment and MDM in the additional_docs file have been replaced by Apple with the current 2022 Apple Platform Deployment Guide. 

This PR links to the new guide.