### PR TITLE
Fix expected result for Calendar.app disabled.

### DIFF
--- a/rules/os/os_calendar_app_disable.yaml
+++ b/rules/os/os_calendar_app_disable.yaml
@@ -23,7 +23,7 @@ check: |
     }
   EOS
 result:
-  string: "false"
+  string: "true"
 fix: |
   This is implemented by a Configuration Profile.
 references:


### PR DESCRIPTION
When Calendar.app is disabled, it should be found, making the expected result 'true' not 'false'