### PR TITLE
Add sysprefs_internet_accounts_prefpane_hide

### DIFF
--- a/baselines/800-171.yaml
+++ b/baselines/800-171.yaml
@@ -131,6 +131,7 @@ profile:
       - sysprefs_hot_corners_disable
       - sysprefs_improve_siri_dictation_disable
       - sysprefs_internet_accounts_prefpane_disable
+      - sysprefs_internet_accounts_prefpane_hide
       - sysprefs_internet_sharing_disable
       - sysprefs_location_services_disable
       - sysprefs_loginwindow_prompt_username_password_enforce
@@ -166,7 +167,7 @@ profile:
       - pwpolicy_50_percent
       - sysprefs_wifi_disable_when_connected_to_ethernet
   - section: "not_applicable"
-    rules: 
+    rules:
       - os_nonlocal_maintenance
   - section: "Supplemental"
     rules:

--- a/baselines/800-53r5_high.yaml
+++ b/baselines/800-53r5_high.yaml
@@ -154,6 +154,7 @@ profile:
       - sysprefs_hot_corners_disable
       - sysprefs_improve_siri_dictation_disable
       - sysprefs_internet_accounts_prefpane_disable
+      - sysprefs_internet_accounts_prefpane_hide
       - sysprefs_internet_sharing_disable
       - sysprefs_location_services_disable
       - sysprefs_loginwindow_prompt_username_password_enforce
@@ -213,7 +214,7 @@ profile:
       - os_secure_name_resolution
       - sysprefs_wifi_disable_when_connected_to_ethernet
   - section: "not_applicable"
-    rules: 
+    rules:
       - os_access_control_mobile_devices
       - os_identify_non-org_users
       - os_information_validation

--- a/baselines/800-53r5_low.yaml
+++ b/baselines/800-53r5_low.yaml
@@ -127,6 +127,7 @@ profile:
       - sysprefs_guest_account_disable
       - sysprefs_improve_siri_dictation_disable
       - sysprefs_internet_accounts_prefpane_disable
+      - sysprefs_internet_accounts_prefpane_hide
       - sysprefs_internet_sharing_disable
       - sysprefs_location_services_disable
       - sysprefs_loginwindow_prompt_username_password_enforce
@@ -164,7 +165,7 @@ profile:
       - os_reauth_devices_change_authenticators
       - os_secure_name_resolution
   - section: "not_applicable"
-    rules: 
+    rules:
       - os_access_control_mobile_devices
       - os_identify_non-org_users
       - os_nonlocal_maintenance

--- a/baselines/800-53r5_moderate.yaml
+++ b/baselines/800-53r5_moderate.yaml
@@ -151,6 +151,7 @@ profile:
       - sysprefs_hot_corners_disable
       - sysprefs_improve_siri_dictation_disable
       - sysprefs_internet_accounts_prefpane_disable
+      - sysprefs_internet_accounts_prefpane_hide
       - sysprefs_internet_sharing_disable
       - sysprefs_location_services_disable
       - sysprefs_loginwindow_prompt_username_password_enforce
@@ -205,7 +206,7 @@ profile:
       - os_secure_name_resolution
       - sysprefs_wifi_disable_when_connected_to_ethernet
   - section: "not_applicable"
-    rules: 
+    rules:
       - os_access_control_mobile_devices
       - os_identify_non-org_users
       - os_information_validation

--- a/baselines/cisv8.yaml
+++ b/baselines/cisv8.yaml
@@ -135,6 +135,7 @@ profile:
       - sysprefs_improve_siri_dictation_disable
       - sysprefs_install_macos_updates_enforce
       - sysprefs_internet_accounts_prefpane_disable
+      - sysprefs_internet_accounts_prefpane_hide
       - sysprefs_internet_sharing_disable
       - sysprefs_location_services_enable
       - sysprefs_loginwindow_loginwindowtext_enable
@@ -180,7 +181,7 @@ profile:
       - os_auth_peripherals
       - os_secure_name_resolution
   - section: "not_applicable"
-    rules: 
+    rules:
       - os_access_control_mobile_devices
   - section: "Supplemental"
     rules:

--- a/baselines/cnssi-1253.yaml
+++ b/baselines/cnssi-1253.yaml
@@ -138,6 +138,7 @@ profile:
       - sysprefs_hot_corners_disable
       - sysprefs_improve_siri_dictation_disable
       - sysprefs_internet_accounts_prefpane_disable
+      - sysprefs_internet_accounts_prefpane_hide
       - sysprefs_internet_sharing_disable
       - sysprefs_location_services_disable
       - sysprefs_loginwindow_prompt_username_password_enforce
@@ -189,7 +190,7 @@ profile:
       - pwpolicy_50_percent
       - sysprefs_wifi_disable_when_connected_to_ethernet
   - section: "not_applicable"
-    rules: 
+    rules:
       - os_identify_non-org_users
       - os_nonlocal_maintenance
   - section: "Supplemental"


### PR DESCRIPTION
The checks for:
sysprefs_internet_accounts_prefpane_disable
sysprefs_internet_accounts_prefpane_hide

Both rules look for 2 (or more) mentions in the system profile as the compliance check.  If only one of the rules is defined for a baseline, then the checks fail.  The best quick fix for this is to always include both rules in a baseline.  