### PR TITLE
Fix issue causing --compliant and --non_compliant to sometimes run when not in cli args

### DIFF
--- a/scripts/generate_guidance.py
+++ b/scripts/generate_guidance.py
@@ -1034,16 +1034,16 @@ fi
 
 }
 
-zparseopts -D -E -check=check -fix=fix -stats=stats -compliant=compliant -non_compliant=non_compliant -reset=reset
+zparseopts -D -E -check=check -fix=fix -stats=stats -compliant=compliant_opt -non_compliant=non_compliant_opt -reset=reset
 
 if [[ $reset ]]; then reset_plist; fi
 
-if [[ $check ]] || [[ $fix ]] || [[ $stats ]] || [[ $compliant ]] || [[ $non_compliant ]]; then
+if [[ $check ]] || [[ $fix ]] || [[ $stats ]] || [[ $compliant_opt ]] || [[ $non_compliant_opt ]]; then
     if [[ $fix ]]; then run_fix; fi
     if [[ $check ]]; then run_scan; fi
     if [[ $stats ]];then generate_stats; fi
-    if [[ $compliant ]];then compliance_count "compliant"; fi
-    if [[ $non_compliant ]];then compliance_count "non-compliant"; fi
+    if [[ $compliant_opt ]];then compliance_count "compliant"; fi
+    if [[ $non_compliant_opt ]];then compliance_count "non-compliant"; fi
 else
     while true; do
         show_menus


### PR DESCRIPTION
The `zparseopts` variable names for `--complaint` and `--non_compliant` collide with the `complaint` and `non_ complaint` variables used in the `compliance_count` function. This caused the cli opts parsing `if` statements to sometimes run an erroneous `--compliant` and/or `--non_compliant` because the corresponding variable was set to non null in the `compliance_count` function.

For example. Running `--compliant` will also output the non compliant count. Similarly running `--stats` will also output the compliant and non compliant numbers.

My solution is to append `_opt` to the `zparseopts` variable names to avoid the name space collision.  
