### PR TITLE
Created Shared Key if Missing for sysprefs_system_wide_preferences_configure

### DIFF
--- a/rules/sysprefs/sysprefs_system_wide_preferences_configure.yaml
+++ b/rules/sysprefs/sysprefs_system_wide_preferences_configure.yaml
@@ -15,8 +15,9 @@ fix: |
   key_value=$(/usr/libexec/PlistBuddy -c "Print :shared" /tmp/system.preferences.plist)
   if [[ "$key_value" == *"Does Not Exist"* ]]; then
     /usr/libexec/PlistBuddy -c "Add :shared bool false" /tmp/system.preferences.plist
+  else
+    /usr/libexec/PlistBuddy -c "Set :shared false" /tmp/system.preferences.plist
   fi
-  /usr/libexec/PlistBuddy -c "Set :shared false" /tmp/system.preferences.plist
   /usr/bin/security authorizationdb write system.preferences < /tmp/system.preferences.plist
   ----
 references:

--- a/rules/sysprefs/sysprefs_system_wide_preferences_configure.yaml
+++ b/rules/sysprefs/sysprefs_system_wide_preferences_configure.yaml
@@ -12,6 +12,10 @@ fix: |
   [source,bash]
   ----
   /usr/bin/security authorizationdb read system.preferences > /tmp/system.preferences.plist
+  key_value=$(/usr/libexec/PlistBuddy -c "Print :shared" /tmp/system.preferences.plist)
+  if [[ "$key_value" == *"Does Not Exist"* ]]; then
+    /usr/libexec/PlistBuddy -c "Add :shared bool false" /tmp/system.preferences.plist
+  fi
   /usr/libexec/PlistBuddy -c "Set :shared false" /tmp/system.preferences.plist
   /usr/bin/security authorizationdb write system.preferences < /tmp/system.preferences.plist
   ----


### PR DESCRIPTION
This should resolve #177. Possibly a better solution for comparison outside of string comparison that can be improved upon down the line.