### PR TITLE
Redirect stderr to stdout to capture the "Does not Exist"

### DIFF
--- a/rules/sysprefs/sysprefs_system_wide_preferences_configure.yaml
+++ b/rules/sysprefs/sysprefs_system_wide_preferences_configure.yaml
@@ -12,7 +12,7 @@ fix: |
   [source,bash]
   ----
   /usr/bin/security authorizationdb read system.preferences > /tmp/system.preferences.plist
-  key_value=$(/usr/libexec/PlistBuddy -c "Print :shared" /tmp/system.preferences.plist)
+  key_value=$(/usr/libexec/PlistBuddy -c "Print :shared" /tmp/system.preferences.plist 2>&1)
   if [[ "$key_value" == *"Does Not Exist"* ]]; then
     /usr/libexec/PlistBuddy -c "Add :shared bool false" /tmp/system.preferences.plist
   else


### PR DESCRIPTION
My fault - did not catch this in my initial testing that what I was intending to capture was in the stderr. Minor change.