### PR TITLE
add rule to disable iCloud based sign-in for Game Center

### DIFF
--- a/baselines/800-171.yaml
+++ b/baselines/800-171.yaml
@@ -45,6 +45,7 @@ profile:
       - icloud_bookmarks_disable
       - icloud_calendar_disable
       - icloud_drive_disable
+      - icloud_game_center_disable
       - icloud_keychain_disable
       - icloud_mail_disable
       - icloud_notes_disable

--- a/baselines/800-53r5_high.yaml
+++ b/baselines/800-53r5_high.yaml
@@ -50,6 +50,7 @@ profile:
       - icloud_bookmarks_disable
       - icloud_calendar_disable
       - icloud_drive_disable
+      - icloud_game_center_disable
       - icloud_keychain_disable
       - icloud_mail_disable
       - icloud_notes_disable

--- a/baselines/800-53r5_low.yaml
+++ b/baselines/800-53r5_low.yaml
@@ -48,6 +48,7 @@ profile:
       - icloud_bookmarks_disable
       - icloud_calendar_disable
       - icloud_drive_disable
+      - icloud_game_center_disable
       - icloud_keychain_disable
       - icloud_mail_disable
       - icloud_notes_disable

--- a/baselines/800-53r5_moderate.yaml
+++ b/baselines/800-53r5_moderate.yaml
@@ -49,6 +49,7 @@ profile:
       - icloud_bookmarks_disable
       - icloud_calendar_disable
       - icloud_drive_disable
+      - icloud_game_center_disable
       - icloud_keychain_disable
       - icloud_mail_disable
       - icloud_notes_disable

--- a/baselines/all_rules.yaml
+++ b/baselines/all_rules.yaml
@@ -56,6 +56,7 @@ profile:
       - icloud_bookmarks_disable
       - icloud_calendar_disable
       - icloud_drive_disable
+      - icloud_game_center_disable
       - icloud_keychain_disable
       - icloud_mail_disable
       - icloud_notes_disable

--- a/baselines/cisv8.yaml
+++ b/baselines/cisv8.yaml
@@ -51,6 +51,7 @@ profile:
       - icloud_bookmarks_disable
       - icloud_calendar_disable
       - icloud_drive_disable
+      - icloud_game_center_disable
       - icloud_keychain_disable
       - icloud_mail_disable
       - icloud_notes_disable

--- a/baselines/cnssi-1253.yaml
+++ b/baselines/cnssi-1253.yaml
@@ -47,6 +47,7 @@ profile:
       - icloud_bookmarks_disable
       - icloud_calendar_disable
       - icloud_drive_disable
+      - icloud_game_center_disable
       - icloud_keychain_disable
       - icloud_mail_disable
       - icloud_notes_disable

--- a/rules/icloud/icloud_game_center_disable.yaml
+++ b/rules/icloud/icloud_game_center_disable.yaml
@@ -1,0 +1,62 @@
+id: icloud_game_center_disable
+title: "Disable iCloud Game Center"
+discussion: |
+  This works only with supervised devices (MDM) and allows to disable Apple Game Center. The rationale is Game Center is using Apple ID and will shared data on AppleID based services, therefore, Game Center _MUST_ be disabled.
+  This setting also prohibits functionality of adding friends to Game Center.
+check: |
+  /usr/bin/osascript -l JavaScript << EOS
+  $.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess')\
+  .objectForKey('allowGameCenter').js
+  EOS
+result:
+  string: "false"
+fix: |
+  This is implemented by a Configuration Profile.
+references:
+  cce:
+    - CCE-91750-0
+  cci:
+    - N/A
+  800-53r5:
+    - AC-20
+    - AC-20(1)
+    - CM-7
+    - CM-7(1)
+    - SC-7(10)    
+  800-53r4:
+    - CM-7
+    - CM-7(1)
+    - AC-20
+    - AC-20(1)
+  srg:
+    - N/A
+  disa_stig:
+    - N/A
+  800-171r2:
+    - 3.1.20
+    - 3.4.6
+  cis:
+    benchmark:
+      - N/A
+    controls v8:
+      - 4.1
+      - 4.8
+      - 15.3    
+macOS:
+  - "13.0"
+tags:
+  - 800-53r5_low 
+  - 800-53r5_moderate 
+  - 800-53r5_high 
+  - 800-53r4_low 
+  - 800-53r4_moderate 
+  - 800-53r4_high 
+  - 800-171
+  - cisv8 
+  - cnssi-1253
+severity: "medium"
+mobileconfig: true
+mobileconfig_info:
+  com.apple.applicationaccess:
+    allowGameCenter: false
+    allowAddingGameCenterFriends: false


### PR DESCRIPTION
I noticed that when iCloud is disabled eg. via mSCP `icloud_appleid_system_settings_disable`mobilconfig, In SytemPrefs logging in to an iCloud account is still possible via GameCenter. To manage/block this, provided is a new rule that adds to `com.apple.applicationaccess` the two settings `allowGameCenter false` and `allowAddingGameCenterFriends false`.

Using this setting will result in GameCenter not accessible as shown in screenshot.  

<img width="827" alt="Screenshot 2022-11-02 at 17 04 17" src="https://user-images.githubusercontent.com/46750/199544800-ec7e2103-d160-49c9-a58e-3b4a311ab36f.png">
