### PR TITLE
[new feature] CMMC Baselines

### DIFF
--- a/baselines/cmmc_lvl1.yaml
+++ b/baselines/cmmc_lvl1.yaml
@@ -1,6 +1,8 @@
 title: "macOS 13.0 (Ventura): Security Configuration - US CMMC 2.0 Level 1"
 description: |
   This guide describes the actions to take when securing a macOS 13.0 system against the US CMMC 2.0 Level 1.
+
+  Information System Security Officers and benchmark creators can use this catalog of settings in order to assist them in security benchmark creation. This list is a catalog, not a checklist or benchmark, and satisfaction of every item is not likely to be possible or sensible in many operational scenarios.
 authors: |
   |===
   |John Mahlman|Leidos

--- a/baselines/cmmc_lvl1.yaml
+++ b/baselines/cmmc_lvl1.yaml
@@ -1,0 +1,93 @@
+title: "macOS 13.0 (Ventura): Security Configuration - US CMMC 2.0 Level 1"
+description: |
+  This guide describes the actions to take when securing a macOS 13.0 system against the US CMMC 2.0 Level 1.
+authors: |
+  |===
+  |John Mahlman|Leidos
+  |===
+parent_values: "recommended"
+profile:
+  - section: "authentication"
+    rules:
+      - auth_smartcard_allow
+      - auth_smartcard_enforce
+      - auth_ssh_password_authentication_disable
+  - section: "icloud"
+    rules:
+      - icloud_addressbook_disable
+      - icloud_appleid_system_settings_disable
+      - icloud_bookmarks_disable
+      - icloud_calendar_disable
+      - icloud_drive_disable
+      - icloud_game_center_disable
+      - icloud_keychain_disable
+      - icloud_mail_disable
+      - icloud_notes_disable
+      - icloud_photos_disable
+      - icloud_private_relay_disable
+      - icloud_reminders_disable
+      - icloud_sync_disable
+  - section: "macos"
+    rules:
+      - os_airdrop_disable
+      - os_appleid_prompt_disable
+      - os_authenticated_root_enable
+      - os_calendar_app_disable
+      - os_config_data_install_enforce
+      - os_facetime_app_disable
+      - os_filevault_autologin_disable
+      - os_firewall_log_enable
+      - os_firmware_password_require
+      - os_gatekeeper_enable
+      - os_gatekeeper_rearm
+      - os_handoff_disable
+      - os_home_folders_secure
+      - os_httpd_disable
+      - os_icloud_storage_prompt_disable
+      - os_mail_app_disable
+      - os_messages_app_disable
+      - os_nfsd_disable
+      - os_rapid_security_response_allow
+      - os_rapid_security_response_removal_disable
+      - os_recovery_lock_enable
+      - os_root_disable
+      - os_sip_enable
+      - os_siri_prompt_disable
+      - os_skip_unlock_with_watch_enable
+      - os_tftpd_disable
+      - os_unlock_active_user_session_disable
+      - os_uucp_disable
+  - section: "systemsettings"
+    rules:
+      - system_settings_automatic_login_disable
+      - system_settings_bluetooth_sharing_disable
+      - system_settings_critical_update_install_enforce
+      - system_settings_diagnostics_reports_disable
+      - system_settings_find_my_disable
+      - system_settings_firewall_enable
+      - system_settings_firewall_stealth_mode_enable
+      - system_settings_guest_access_smb_disable
+      - system_settings_guest_account_disable
+      - system_settings_improve_siri_dictation_disable
+      - system_settings_internet_accounts_disable
+      - system_settings_internet_sharing_disable
+      - system_settings_loginwindow_prompt_username_password_enforce
+      - system_settings_media_sharing_disabled
+      - system_settings_personalized_advertising_disable
+      - system_settings_rae_disable
+      - system_settings_screen_sharing_disable
+      - system_settings_siri_disable
+      - system_settings_smbd_disable
+      - system_settings_ssh_disable
+      - system_settings_system_wide_preferences_configure
+  - section: "Inherent"
+    rules:
+      - os_logical_access
+      - os_malicious_code_prevention
+  - section: "Supplemental"
+    rules:
+      - supplemental_controls
+      - supplemental_filevault
+      - supplemental_firewall_pf
+      - supplemental_password_policy
+      - supplemental_smartcard

--- a/baselines/cmmc_lvl1.yaml
+++ b/baselines/cmmc_lvl1.yaml
@@ -6,6 +6,9 @@ description: |
 authors: |
   |===
   |John Mahlman|Leidos
+  |Bob Gendler|National Institute of Standards and Technology
+  |Dan Brodjieski|National Aeronautics and Space Administration
+  |Allen Golbig|Jamf
   |===
 parent_values: "recommended"
 profile:

--- a/baselines/cmmc_lvl2.yaml
+++ b/baselines/cmmc_lvl2.yaml
@@ -1,6 +1,8 @@
 title: "macOS 13.0 (Ventura): Security Configuration - US CMMC 2.0 Level 2"
 description: |
   This guide describes the actions to take when securing a macOS 13.0 system against the US CMMC 2.0 Level 2.
+
+  Information System Security Officers and benchmark creators can use this catalog of settings in order to assist them in security benchmark creation. This list is a catalog, not a checklist or benchmark, and satisfaction of every item is not likely to be possible or sensible in many operational scenarios.
 authors: |
   |===
   |John Mahlman|Leidos

--- a/baselines/cmmc_lvl2.yaml
+++ b/baselines/cmmc_lvl2.yaml
@@ -1,0 +1,219 @@
+title: "macOS 13.0 (Ventura): Security Configuration - US CMMC 2.0 Level 2"
+description: |
+  This guide describes the actions to take when securing a macOS 13.0 system against the US CMMC 2.0 Level 2.
+authors: |
+  |===
+  |John Mahlman|Leidos
+  |===
+parent_values: "recommended"
+profile:
+  - section: "auditing"
+    rules:
+      - audit_acls_files_configure
+      - audit_acls_folders_configure
+      - audit_auditd_enabled
+      - audit_control_acls_configure
+      - audit_control_group_configure
+      - audit_control_mode_configure
+      - audit_control_owner_configure
+      - audit_failure_halt
+      - audit_files_group_configure
+      - audit_files_mode_configure
+      - audit_files_owner_configure
+      - audit_flags_aa_configure
+      - audit_flags_ad_configure
+      - audit_flags_ex_configure
+      - audit_flags_fd_configure
+      - audit_flags_fm_configure
+      - audit_flags_fm_failed_configure
+      - audit_flags_fr_configure
+      - audit_flags_fw_configure
+      - audit_flags_lo_configure
+      - audit_folder_group_configure
+      - audit_folder_owner_configure
+      - audit_folders_mode_configure
+      - audit_retention_configure
+      - audit_settings_failure_notify
+  - section: "authentication"
+    rules:
+      - auth_pam_login_smartcard_enforce
+      - auth_pam_su_smartcard_enforce
+      - auth_pam_sudo_smartcard_enforce
+      - auth_smartcard_allow
+      - auth_smartcard_certificate_trust_enforce_moderate
+      - auth_smartcard_enforce
+      - auth_ssh_password_authentication_disable
+  - section: "icloud"
+    rules:
+      - icloud_addressbook_disable
+      - icloud_appleid_system_settings_disable
+      - icloud_bookmarks_disable
+      - icloud_calendar_disable
+      - icloud_drive_disable
+      - icloud_game_center_disable
+      - icloud_keychain_disable
+      - icloud_mail_disable
+      - icloud_notes_disable
+      - icloud_photos_disable
+      - icloud_private_relay_disable
+      - icloud_reminders_disable
+      - icloud_sync_disable
+  - section: "macos"
+    rules:
+      - os_airdrop_disable
+      - os_appleid_prompt_disable
+      - os_authenticated_root_enable
+      - os_blank_bluray_disable
+      - os_blank_cd_disable
+      - os_blank_dvd_disable
+      - os_bluray_read_only_enforce
+      - os_bonjour_disable
+      - os_burn_support_disable
+      - os_calendar_app_disable
+      - os_cd_read_only_enforce
+      - os_certificate_authority_trust
+      - os_config_data_install_enforce
+      - os_config_profile_ui_install_disable
+      - os_disk_image_disable
+      - os_dvdram_disable
+      - os_erase_content_and_settings_disable
+      - os_facetime_app_disable
+      - os_filevault_autologin_disable
+      - os_firewall_default_deny_require
+      - os_firewall_log_enable
+      - os_firmware_password_require
+      - os_gatekeeper_enable
+      - os_gatekeeper_rearm
+      - os_handoff_disable
+      - os_home_folders_secure
+      - os_httpd_disable
+      - os_icloud_storage_prompt_disable
+      - os_install_log_retention_configure
+      - os_ir_support_disable
+      - os_mail_app_disable
+      - os_mdm_require
+      - os_messages_app_disable
+      - os_nfsd_disable
+      - os_password_autofill_disable
+      - os_password_hint_remove
+      - os_password_proximity_disable
+      - os_password_sharing_disable
+      - os_policy_banner_loginwindow_enforce
+      - os_policy_banner_ssh_configure
+      - os_policy_banner_ssh_enforce
+      - os_power_nap_disable
+      - os_privacy_setup_prompt_disable
+      - os_rapid_security_response_allow
+      - os_rapid_security_response_removal_disable
+      - os_recovery_lock_enable
+      - os_removable_media_disable
+      - os_root_disable
+      - os_sip_enable
+      - os_siri_prompt_disable
+      - os_skip_screen_time_prompt_enable
+      - os_skip_unlock_with_watch_enable
+      - os_ssh_fips_compliant
+      - os_ssh_server_alive_count_max_configure
+      - os_ssh_server_alive_interval_configure
+      - os_sshd_client_alive_count_max_configure
+      - os_sshd_client_alive_interval_configure
+      - os_sshd_fips_140_ciphers
+      - os_sshd_fips_140_macs
+      - os_sshd_fips_compliant
+      - os_sshd_key_exchange_algorithm_configure
+      - os_sshd_login_grace_time_configure
+      - os_tftpd_disable
+      - os_time_server_enabled
+      - os_touchid_prompt_disable
+      - os_unlock_active_user_session_disable
+      - os_user_app_installation_prohibit
+      - os_uucp_disable
+  - section: "passwordpolicy"
+    rules:
+      - pwpolicy_account_inactivity_enforce
+      - pwpolicy_account_lockout_enforce
+      - pwpolicy_account_lockout_timeout_enforce
+      - pwpolicy_alpha_numeric_enforce
+      - pwpolicy_history_enforce
+      - pwpolicy_lower_case_character_enforce
+      - pwpolicy_max_lifetime_enforce
+      - pwpolicy_minimum_length_enforce
+      - pwpolicy_minimum_lifetime_enforce
+      - pwpolicy_simple_sequence_disable
+      - pwpolicy_special_character_enforce
+      - pwpolicy_upper_case_character_enforce
+  - section: "systemsettings"
+    rules:
+      - system_settings_airplay_receiver_disable
+      - system_settings_apple_watch_unlock_disable
+      - system_settings_automatic_login_disable
+      - system_settings_automatic_logout_enforce
+      - system_settings_bluetooth_disable
+      - system_settings_bluetooth_sharing_disable
+      - system_settings_cd_dvd_sharing_disable
+      - system_settings_content_caching_disable
+      - system_settings_critical_update_install_enforce
+      - system_settings_diagnostics_reports_disable
+      - system_settings_filevault_enforce
+      - system_settings_find_my_disable
+      - system_settings_firewall_enable
+      - system_settings_firewall_stealth_mode_enable
+      - system_settings_gatekeeper_identified_developers_allowed
+      - system_settings_gatekeeper_override_disallow
+      - system_settings_guest_access_smb_disable
+      - system_settings_guest_account_disable
+      - system_settings_improve_siri_dictation_disable
+      - system_settings_internet_accounts_disable
+      - system_settings_internet_sharing_disable
+      - system_settings_location_services_disable
+      - system_settings_loginwindow_prompt_username_password_enforce
+      - system_settings_media_sharing_disabled
+      - system_settings_password_hints_disable
+      - system_settings_personalized_advertising_disable
+      - system_settings_printer_sharing_disable
+      - system_settings_rae_disable
+      - system_settings_remote_management_disable
+      - system_settings_screen_sharing_disable
+      - system_settings_screensaver_ask_for_password_delay_enforce
+      - system_settings_screensaver_password_enforce
+      - system_settings_screensaver_timeout_enforce
+      - system_settings_siri_disable
+      - system_settings_smbd_disable
+      - system_settings_ssh_disable
+      - system_settings_system_wide_preferences_configure
+      - system_settings_time_server_configure
+      - system_settings_time_server_enforce
+      - system_settings_token_removal_enforce
+      - system_settings_touchid_unlock_disable
+      - system_settings_usb_restricted_mode
+      - system_settings_wifi_disable
+  - section: "Inherent"
+    rules:
+      - audit_record_reduction_report_generation
+      - os_implement_cryptography
+      - os_logical_access
+      - os_malicious_code_prevention
+      - os_obscure_password
+      - os_prevent_priv_functions
+      - os_prevent_unauthorized_disclosure
+      - os_prohibit_remote_activation_collab_devices
+      - os_separate_functionality
+      - os_store_encrypted_passwords
+      - os_unique_identification
+      - pwpolicy_force_password_change
+  - section: "Permanent"
+    rules:
+      - audit_records_processing
+      - system_settings_wifi_disable_when_connected_to_ethernet
+  - section: "not_applicable"
+    rules: 
+      - os_access_control_mobile_devices
+      - os_managed_access_control_points
+      - os_nonlocal_maintenance
+  - section: "Supplemental"
+    rules:
+      - supplemental_controls
+      - supplemental_filevault
+      - supplemental_firewall_pf
+      - supplemental_password_policy
+      - supplemental_smartcard

--- a/baselines/cmmc_lvl2.yaml
+++ b/baselines/cmmc_lvl2.yaml
@@ -6,6 +6,9 @@ description: |
 authors: |
   |===
   |John Mahlman|Leidos
+  |Bob Gendler|National Institute of Standards and Technology
+  |Dan Brodjieski|National Aeronautics and Space Administration
+  |Allen Golbig|Jamf
   |===
 parent_values: "recommended"
 profile:

--- a/baselines/cmmc_lvl3.yaml
+++ b/baselines/cmmc_lvl3.yaml
@@ -1,0 +1,221 @@
+title: "macOS 13.0 (Ventura): Security Configuration - US CMMC 2.0 Level 3"
+description: |
+  This guide describes the actions to take when securing a macOS 13.0 system against the US CMMC 2.0 Level 3.
+authors: |
+  |===
+  |John Mahlman|Leidos
+  |===
+parent_values: "recommended"
+profile:
+  - section: "auditing"
+    rules:
+      - audit_acls_files_configure
+      - audit_acls_folders_configure
+      - audit_auditd_enabled
+      - audit_control_acls_configure
+      - audit_control_group_configure
+      - audit_control_mode_configure
+      - audit_control_owner_configure
+      - audit_failure_halt
+      - audit_files_group_configure
+      - audit_files_mode_configure
+      - audit_files_owner_configure
+      - audit_flags_aa_configure
+      - audit_flags_ad_configure
+      - audit_flags_ex_configure
+      - audit_flags_fd_configure
+      - audit_flags_fm_configure
+      - audit_flags_fm_failed_configure
+      - audit_flags_fr_configure
+      - audit_flags_fw_configure
+      - audit_flags_lo_configure
+      - audit_folder_group_configure
+      - audit_folder_owner_configure
+      - audit_folders_mode_configure
+      - audit_retention_configure
+      - audit_settings_failure_notify
+  - section: "authentication"
+    rules:
+      - auth_pam_login_smartcard_enforce
+      - auth_pam_su_smartcard_enforce
+      - auth_pam_sudo_smartcard_enforce
+      - auth_smartcard_allow
+      - auth_smartcard_certificate_trust_enforce_moderate
+      - auth_smartcard_enforce
+      - auth_ssh_password_authentication_disable
+  - section: "icloud"
+    rules:
+      - icloud_addressbook_disable
+      - icloud_appleid_system_settings_disable
+      - icloud_bookmarks_disable
+      - icloud_calendar_disable
+      - icloud_drive_disable
+      - icloud_game_center_disable
+      - icloud_keychain_disable
+      - icloud_mail_disable
+      - icloud_notes_disable
+      - icloud_photos_disable
+      - icloud_private_relay_disable
+      - icloud_reminders_disable
+      - icloud_sync_disable
+  - section: "macos"
+    rules:
+      - os_airdrop_disable
+      - os_appleid_prompt_disable
+      - os_authenticated_root_enable
+      - os_blank_bluray_disable
+      - os_blank_cd_disable
+      - os_blank_dvd_disable
+      - os_bluray_read_only_enforce
+      - os_bonjour_disable
+      - os_burn_support_disable
+      - os_calendar_app_disable
+      - os_cd_read_only_enforce
+      - os_certificate_authority_trust
+      - os_config_data_install_enforce
+      - os_config_profile_ui_install_disable
+      - os_disk_image_disable
+      - os_dvdram_disable
+      - os_erase_content_and_settings_disable
+      - os_facetime_app_disable
+      - os_filevault_autologin_disable
+      - os_firewall_default_deny_require
+      - os_firewall_log_enable
+      - os_firmware_password_require
+      - os_gatekeeper_enable
+      - os_gatekeeper_rearm
+      - os_handoff_disable
+      - os_home_folders_secure
+      - os_httpd_disable
+      - os_icloud_storage_prompt_disable
+      - os_install_log_retention_configure
+      - os_ir_support_disable
+      - os_mail_app_disable
+      - os_mdm_require
+      - os_messages_app_disable
+      - os_nfsd_disable
+      - os_password_autofill_disable
+      - os_password_hint_remove
+      - os_password_proximity_disable
+      - os_password_sharing_disable
+      - os_policy_banner_loginwindow_enforce
+      - os_policy_banner_ssh_configure
+      - os_policy_banner_ssh_enforce
+      - os_power_nap_disable
+      - os_privacy_setup_prompt_disable
+      - os_rapid_security_response_allow
+      - os_rapid_security_response_removal_disable
+      - os_recovery_lock_enable
+      - os_removable_media_disable
+      - os_root_disable
+      - os_sip_enable
+      - os_siri_prompt_disable
+      - os_skip_screen_time_prompt_enable
+      - os_skip_unlock_with_watch_enable
+      - os_ssh_fips_compliant
+      - os_ssh_server_alive_count_max_configure
+      - os_ssh_server_alive_interval_configure
+      - os_sshd_client_alive_count_max_configure
+      - os_sshd_client_alive_interval_configure
+      - os_sshd_fips_140_ciphers
+      - os_sshd_fips_140_macs
+      - os_sshd_fips_compliant
+      - os_sshd_key_exchange_algorithm_configure
+      - os_sshd_login_grace_time_configure
+      - os_tftpd_disable
+      - os_time_server_enabled
+      - os_touchid_prompt_disable
+      - os_unlock_active_user_session_disable
+      - os_user_app_installation_prohibit
+      - os_uucp_disable
+  - section: "passwordpolicy"
+    rules:
+      - pwpolicy_account_inactivity_enforce
+      - pwpolicy_account_lockout_enforce
+      - pwpolicy_account_lockout_timeout_enforce
+      - pwpolicy_alpha_numeric_enforce
+      - pwpolicy_history_enforce
+      - pwpolicy_lower_case_character_enforce
+      - pwpolicy_max_lifetime_enforce
+      - pwpolicy_minimum_length_enforce
+      - pwpolicy_minimum_lifetime_enforce
+      - pwpolicy_simple_sequence_disable
+      - pwpolicy_special_character_enforce
+      - pwpolicy_upper_case_character_enforce
+  - section: "systemsettings"
+    rules:
+      - system_settings_airplay_receiver_disable
+      - system_settings_apple_watch_unlock_disable
+      - system_settings_automatic_login_disable
+      - system_settings_automatic_logout_enforce
+      - system_settings_bluetooth_disable
+      - system_settings_bluetooth_sharing_disable
+      - system_settings_cd_dvd_sharing_disable
+      - system_settings_content_caching_disable
+      - system_settings_critical_update_install_enforce
+      - system_settings_diagnostics_reports_disable
+      - system_settings_filevault_enforce
+      - system_settings_find_my_disable
+      - system_settings_firewall_enable
+      - system_settings_firewall_stealth_mode_enable
+      - system_settings_gatekeeper_identified_developers_allowed
+      - system_settings_gatekeeper_override_disallow
+      - system_settings_guest_access_smb_disable
+      - system_settings_guest_account_disable
+      - system_settings_improve_siri_dictation_disable
+      - system_settings_internet_accounts_disable
+      - system_settings_internet_sharing_disable
+      - system_settings_location_services_disable
+      - system_settings_loginwindow_prompt_username_password_enforce
+      - system_settings_media_sharing_disabled
+      - system_settings_password_hints_disable
+      - system_settings_personalized_advertising_disable
+      - system_settings_printer_sharing_disable
+      - system_settings_rae_disable
+      - system_settings_remote_management_disable
+      - system_settings_screen_sharing_disable
+      - system_settings_screensaver_ask_for_password_delay_enforce
+      - system_settings_screensaver_password_enforce
+      - system_settings_screensaver_timeout_enforce
+      - system_settings_siri_disable
+      - system_settings_smbd_disable
+      - system_settings_ssh_disable
+      - system_settings_system_wide_preferences_configure
+      - system_settings_time_server_configure
+      - system_settings_time_server_enforce
+      - system_settings_token_removal_enforce
+      - system_settings_touchid_unlock_disable
+      - system_settings_usb_restricted_mode
+      - system_settings_wifi_disable
+  - section: "Inherent"
+    rules:
+      - audit_record_reduction_report_generation
+      - os_implement_cryptography
+      - os_isolate_security_functions
+      - os_logical_access
+      - os_malicious_code_prevention
+      - os_obscure_password
+      - os_prevent_priv_functions
+      - os_prevent_unauthorized_disclosure
+      - os_prohibit_remote_activation_collab_devices
+      - os_separate_functionality
+      - os_store_encrypted_passwords
+      - os_unique_identification
+      - pwpolicy_force_password_change
+  - section: "Permanent"
+    rules:
+      - audit_enforce_dual_auth
+      - audit_records_processing
+      - system_settings_wifi_disable_when_connected_to_ethernet
+  - section: "not_applicable"
+    rules: 
+      - os_access_control_mobile_devices
+      - os_managed_access_control_points
+      - os_nonlocal_maintenance
+  - section: "Supplemental"
+    rules:
+      - supplemental_controls
+      - supplemental_filevault
+      - supplemental_firewall_pf
+      - supplemental_password_policy
+      - supplemental_smartcard

--- a/baselines/cmmc_lvl3.yaml
+++ b/baselines/cmmc_lvl3.yaml
@@ -193,7 +193,6 @@ profile:
     rules:
       - audit_record_reduction_report_generation
       - os_implement_cryptography
-      - os_isolate_security_functions
       - os_logical_access
       - os_malicious_code_prevention
       - os_obscure_password
@@ -206,7 +205,6 @@ profile:
       - pwpolicy_force_password_change
   - section: "Permanent"
     rules:
-      - audit_enforce_dual_auth
       - audit_records_processing
       - system_settings_wifi_disable_when_connected_to_ethernet
   - section: "not_applicable"

--- a/baselines/cmmc_lvl3.yaml
+++ b/baselines/cmmc_lvl3.yaml
@@ -1,6 +1,8 @@
 title: "macOS 13.0 (Ventura): Security Configuration - US CMMC 2.0 Level 3"
 description: |
   This guide describes the actions to take when securing a macOS 13.0 system against the US CMMC 2.0 Level 3.
+
+  Information System Security Officers and benchmark creators can use this catalog of settings in order to assist them in security benchmark creation. This list is a catalog, not a checklist or benchmark, and satisfaction of every item is not likely to be possible or sensible in many operational scenarios.
 authors: |
   |===
   |John Mahlman|Leidos

--- a/baselines/cmmc_lvl3.yaml
+++ b/baselines/cmmc_lvl3.yaml
@@ -6,6 +6,9 @@ description: |
 authors: |
   |===
   |John Mahlman|Leidos
+  |Bob Gendler|National Institute of Standards and Technology
+  |Dan Brodjieski|National Aeronautics and Space Administration
+  |Allen Golbig|Jamf
   |===
 parent_values: "recommended"
 profile:

--- a/includes/mscp-data.yaml
+++ b/includes/mscp-data.yaml
@@ -44,6 +44,24 @@ authors:
       - Bob Gendler|National Institute of Standards and Technology
       - Dan Brodjieski|National Aeronautics and Space Administration
       - Allen Golbig|Jamf
+  cmmc_lvl1:
+    names:
+      - John Mahlman|Leidos
+      - Bob Gendler|National Institute of Standards and Technology
+      - Dan Brodjieski|National Aeronautics and Space Administration
+      - Allen Golbig|Jamf
+  cmmc_lvl2:
+    names:
+      - John Mahlman|Leidos
+      - Bob Gendler|National Institute of Standards and Technology
+      - Dan Brodjieski|National Aeronautics and Space Administration
+      - Allen Golbig|Jamf
+  cmmc_lvl3:
+    names:
+      - John Mahlman|Leidos
+      - Bob Gendler|National Institute of Standards and Technology
+      - Dan Brodjieski|National Aeronautics and Space Administration
+      - Allen Golbig|Jamf
   cnssi-1253:
     names:
       - Rob Lamb|Los Alamos National Laboratory
@@ -57,5 +75,8 @@ titles:
   800-171: NIST 800-171 Rev 2
   cis_lvl1: CIS Apple macOS 13.0 Ventura v1.0.0 Benchmark (Level 1)
   cis_lvl2: CIS Apple macOS 13.0 Ventura v1.0.0 Benchmark (Level 2)
+  cmmc_lvl1: Cybersecurity Maturity Model Certification (Level 1)
+  cmmc_lvl2: Cybersecurity Maturity Model Certification (Level 2)
+  cmmc_lvl3: Cybersecurity Maturity Model Certification (Level 3)
   cisv8: CIS Controls Version 8
   cnssi-1253: Committee on National Security Systems Instruction No. 1253

--- a/rules/audit/audit_acls_files_configure.yaml
+++ b/rules/audit/audit_acls_files_configure.yaml
@@ -33,6 +33,8 @@ references:
       - 3.5 (level 1)
     controls v8:
       - 3.3
+  cmmc:
+    - AU.L2-3.3.8
 macOS:
   - "13.0"
 tags:
@@ -47,6 +49,8 @@ tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: false
 mobileconfig_info:

--- a/rules/audit/audit_acls_folders_configure.yaml
+++ b/rules/audit/audit_acls_folders_configure.yaml
@@ -33,6 +33,8 @@ references:
       - 3.5 (level 1)
     controls v8:
       - 3.3
+  cmmc:
+    - AU.L2-3.3.8
 macOS:
   - "13.0"
 tags:
@@ -47,6 +49,8 @@ tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: false
 mobileconfig_info:

--- a/rules/audit/audit_auditd_enabled.yaml
+++ b/rules/audit/audit_auditd_enabled.yaml
@@ -55,6 +55,9 @@ references:
     controls v8:
       - 8.2
       - 8.5
+  cmmc:
+    - AU.L2-3.3.2
+    - AU.L2-3.3.6
 macOS:
   - "13.0"
 tags:
@@ -69,6 +72,8 @@ tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: false
 mobileconfig_info:

--- a/rules/audit/audit_control_acls_configure.yaml
+++ b/rules/audit/audit_control_acls_configure.yaml
@@ -31,11 +31,15 @@ references:
       - 3.5 (level 1)
     controls v8:
       - 3.3
+  cmmc:
+    - AU.L2-3.3.8
 macOS:
   - "13.0"
 tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 mobileconfig: false
 mobileconfig_info:

--- a/rules/audit/audit_control_group_configure.yaml
+++ b/rules/audit/audit_control_group_configure.yaml
@@ -31,11 +31,15 @@ references:
       - 3.5 (level 1)
     controls v8:
       - 3.3
+  cmmc:
+    - AU.L2-3.3.8
 macOS:
   - "13.0"
 tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 mobileconfig: false
 mobileconfig_info:

--- a/rules/audit/audit_control_mode_configure.yaml
+++ b/rules/audit/audit_control_mode_configure.yaml
@@ -31,11 +31,15 @@ references:
       - 3.5 (level 1)
     controls v8:
       - 3.3
+  cmmc:
+    - AU.L2-3.3.8
 macOS:
   - "13.0"
 tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 mobileconfig: false
 mobileconfig_info:

--- a/rules/audit/audit_control_owner_configure.yaml
+++ b/rules/audit/audit_control_owner_configure.yaml
@@ -31,11 +31,15 @@ references:
       - 3.5 (level 1)
     controls v8:
       - 3.3
+  cmmc:
+    - AU.L2-3.3.8
 macOS:
   - "13.0"
 tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 mobileconfig: false
 mobileconfig_info:

--- a/rules/audit/audit_failure_halt.yaml
+++ b/rules/audit/audit_failure_halt.yaml
@@ -28,6 +28,8 @@ references:
     - N/A
   800-171r2:
     - 3.3.4
+  cmmc:
+    - AU.L2-3.3.4
 macOS:
   - "13.0"
 tags:
@@ -39,6 +41,8 @@ tags:
   - 800-53r4_high 
   - 800-171 
   - cnssi-1253
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: false
 mobileconfig_info:

--- a/rules/audit/audit_files_group_configure.yaml
+++ b/rules/audit/audit_files_group_configure.yaml
@@ -35,6 +35,8 @@ references:
       - 3.5 (level 1)
     controls v8:
       - 3.3
+  cmmc:
+    - AU.L2-3.3.8
 macOS:
   - "13.0"
 tags:
@@ -49,6 +51,8 @@ tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: false
 mobileconfig_info:

--- a/rules/audit/audit_files_mode_configure.yaml
+++ b/rules/audit/audit_files_mode_configure.yaml
@@ -31,6 +31,8 @@ references:
       - 3.5 (level 1)
     controls v8:
       - 3.3
+  cmmc:
+    - AU.L2-3.3.8
 macOS:
   - "13.0"
 tags:
@@ -45,6 +47,8 @@ tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: false
 mobileconfig_info:

--- a/rules/audit/audit_files_owner_configure.yaml
+++ b/rules/audit/audit_files_owner_configure.yaml
@@ -35,6 +35,8 @@ references:
       - 3.5 (level 1)
     controls v8:
       - 3.3
+  cmmc:
+    - AU.L2-3.3.8
 macOS:
   - "13.0"
 tags:
@@ -49,6 +51,8 @@ tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: false
 mobileconfig_info:

--- a/rules/audit/audit_flags_aa_configure.yaml
+++ b/rules/audit/audit_flags_aa_configure.yaml
@@ -43,7 +43,12 @@ references:
     controls v8:
       - 3.14
       - 8.2
-      - 8.5    
+      - 8.5
+  cmmc:
+    - AU.L2-3.3.3
+    - AU.L2-3.3.6
+    - SI.L2-3.14.3
+    - TBD - 3.14.2e
 macOS:
   - "13.0"
 tags:
@@ -58,6 +63,8 @@ tags:
   - cnssi-1253
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: false
 mobileconfig_info:

--- a/rules/audit/audit_flags_ad_configure.yaml
+++ b/rules/audit/audit_flags_ad_configure.yaml
@@ -52,7 +52,12 @@ references:
     controls v8:
       - 3.14
       - 8.2
-      - 8.5    
+      - 8.5
+  cmmc:
+    - AU.L2-3.3.3
+    - AU.L2-3.3.6
+    - SI.L2-3.14.3
+    - TBD - 3.14.2e
 macOS:
   - "13.0"
 tags:
@@ -67,6 +72,8 @@ tags:
   - cnssi-1253
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: false
 mobileconfig_info:

--- a/rules/audit/audit_flags_ex_configure.yaml
+++ b/rules/audit/audit_flags_ex_configure.yaml
@@ -43,7 +43,12 @@ references:
     controls v8:
       - 3.14
       - 8.2
-      - 8.5    
+      - 8.5
+  cmmc:
+    - AU.L2-3.3.3
+    - AU.L2-3.3.6
+    - SI.L2-3.14.3
+    - TBD - 3.14.2e
 macOS:
   - "13.0"
 tags:
@@ -58,5 +63,7 @@ tags:
   - cnssi-1253
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 mobileconfig: false
 mobileconfig_info:

--- a/rules/audit/audit_flags_fd_configure.yaml
+++ b/rules/audit/audit_flags_fd_configure.yaml
@@ -41,6 +41,12 @@ references:
     - N/A
   800-171r2:
     - N/A
+  cmmc:
+    - AU.L2-3.3.3
+    - AU.L2-3.3.6
+    - AU.L2-3.3.8
+    - SI.L2-3.14.3
+    - TBD - 3.14.2e
 macOS:
   - "13.0"
 tags:
@@ -48,6 +54,8 @@ tags:
   - 800-53r5_low 
   - 800-53r5_moderate 
   - 800-53r5_high
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: false
 mobileconfig_info:

--- a/rules/audit/audit_flags_fm_configure.yaml
+++ b/rules/audit/audit_flags_fm_configure.yaml
@@ -41,10 +41,18 @@ references:
     - N/A
   800-171r2:
     - N/A
+  cmmc:
+    - AU.L2-3.3.3
+    - AU.L2-3.3.6
+    - AU.L2-3.3.8
+    - SI.L2-3.14.3
+    - TBD - 3.14.2e
 macOS:
   - "13.0"
 tags:
   - none
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: false
 mobileconfig_info:

--- a/rules/audit/audit_flags_fm_failed_configure.yaml
+++ b/rules/audit/audit_flags_fm_failed_configure.yaml
@@ -50,6 +50,12 @@ references:
       - 3.14
       - 8.2
       - 8.5
+  cmmc:
+    - AU.L2-3.3.3
+    - AU.L2-3.3.6
+    - AU.L2-3.3.8
+    - SI.L2-3.14.3
+    - TBD - 3.14.2e
 macOS:
   - "13.0"
 tags:
@@ -64,6 +70,8 @@ tags:
   - 800-53r4_high
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: false
 mobileconfig_info:

--- a/rules/audit/audit_flags_fr_configure.yaml
+++ b/rules/audit/audit_flags_fr_configure.yaml
@@ -49,7 +49,13 @@ references:
     controls v8:
       - 3.14
       - 8.2
-      - 8.5    
+      - 8.5
+  cmmc:
+    - AU.L2-3.3.3
+    - AU.L2-3.3.6
+    - AU.L2-3.3.8
+    - SI.L2-3.14.3
+    - TBD - 3.14.2e
 macOS:
   - "13.0"
 tags:
@@ -64,6 +70,8 @@ tags:
   - cnssi-1253
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: false
 mobileconfig_info:

--- a/rules/audit/audit_flags_fw_configure.yaml
+++ b/rules/audit/audit_flags_fw_configure.yaml
@@ -49,7 +49,13 @@ references:
     controls v8:
       - 3.14
       - 8.2
-      - 8.5    
+      - 8.5
+  cmmc:
+    - AU.L2-3.3.3
+    - AU.L2-3.3.6
+    - AU.L2-3.3.8
+    - SI.L2-3.14.3
+    - TBD - 3.14.2e
 macOS:
   - "13.0"
 tags:
@@ -64,6 +70,8 @@ tags:
   - cnssi-1253
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: false
 mobileconfig_info:

--- a/rules/audit/audit_flags_lo_configure.yaml
+++ b/rules/audit/audit_flags_lo_configure.yaml
@@ -45,7 +45,13 @@ references:
     controls v8:
       - 3.14
       - 8.2
-      - 8.5    
+      - 8.5
+  cmmc:
+    - AC.L2-3.1.12
+    - AU.L2-3.3.3
+    - AU.L2-3.3.6
+    - SI.L2-3.14.3
+    - TBD - 3.14.2e
 macOS:
   - "13.0"
 tags:
@@ -60,6 +66,8 @@ tags:
   - cnssi-1253
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: false
 mobileconfig_info:

--- a/rules/audit/audit_folder_group_configure.yaml
+++ b/rules/audit/audit_folder_group_configure.yaml
@@ -35,6 +35,8 @@ references:
       - 3.5 (level 1)
     controls v8:
       - 3.3
+  cmmc:
+    - AU.L2-3.3.8
 macOS:
   - "13.0"
 tags:
@@ -49,6 +51,8 @@ tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: false
 mobileconfig_info:

--- a/rules/audit/audit_folder_owner_configure.yaml
+++ b/rules/audit/audit_folder_owner_configure.yaml
@@ -35,6 +35,8 @@ references:
       - 3.5 (level 1)
     controls v8:
       - 3.3
+  cmmc:
+    - AU.L2-3.3.8
 macOS:
   - "13.0"
 tags:
@@ -49,6 +51,8 @@ tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: false
 mobileconfig_info:

--- a/rules/audit/audit_folders_mode_configure.yaml
+++ b/rules/audit/audit_folders_mode_configure.yaml
@@ -33,6 +33,8 @@ references:
       - 3.5 (level 1)
     controls v8:
       - 3.3
+  cmmc:
+    - AU.L2-3.3.8
 macOS:
   - "13.0"
 tags:
@@ -47,6 +49,8 @@ tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: false
 mobileconfig_info:

--- a/rules/audit/audit_record_reduction_report_generation.yaml
+++ b/rules/audit/audit_record_reduction_report_generation.yaml
@@ -25,6 +25,8 @@ references:
     - N/A
   800-171r2:
     - N/A
+  cmmc:
+    - AU.L2-3.3.6
 macOS:
   - "13.0"
 tags:
@@ -32,5 +34,7 @@ tags:
   - 800-53r4_high
   - 800-53r5_moderate
   - inherent
+  - cmmc_lvl3
+  - cmmc_lvl2
 mobileconfig: false
 mobileconfig_info:

--- a/rules/audit/audit_records_processing.yaml
+++ b/rules/audit/audit_records_processing.yaml
@@ -23,6 +23,8 @@ references:
     - N/A
   800-171r2:
     - N/A
+  cmmc:
+    - AU.L2-3.3.6
 macOS:
   - "13.0"
 tags:
@@ -30,5 +32,7 @@ tags:
   - 800-53r4_high
   - 800-53r5_moderate
   - permanent
+  - cmmc_lvl3
+  - cmmc_lvl2
 mobileconfig: false
 mobileconfig_info:

--- a/rules/audit/audit_retention_configure.yaml
+++ b/rules/audit/audit_retention_configure.yaml
@@ -34,6 +34,8 @@ references:
     controls v8:
       - 8.1
       - 8.3
+  cmmc:
+    - AU.L2-3.3.1
 macOS:
   - "13.0"
 odv:
@@ -53,6 +55,8 @@ tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: false
 mobileconfig_info:

--- a/rules/audit/audit_settings_failure_notify.yaml
+++ b/rules/audit/audit_settings_failure_notify.yaml
@@ -30,6 +30,8 @@ references:
     - N/A
   800-171r2:
     - 3.3.4
+  cmmc:
+    - AU.L2-3.3.4
 macOS:
   - "13.0"
 tags:
@@ -38,6 +40,8 @@ tags:
   - 800-53r4_high 
   - 800-53r5_high 
   - 800-171
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: false
 mobileconfig_info:

--- a/rules/auth/auth_pam_login_smartcard_enforce.yaml
+++ b/rules/auth/auth_pam_login_smartcard_enforce.yaml
@@ -61,6 +61,10 @@ references:
       - 6.3
       - 6.4
       - 6.5
+  cmmc:
+    - IA.L2-3.5.3
+    - IA.L2-3.5.4
+    - TBD - 3.5.1e
 macOS:
   - "13.0"
 tags:
@@ -73,6 +77,8 @@ tags:
   - 800-171 
   - cnssi-1253
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: false
 mobileconfig_info:

--- a/rules/auth/auth_pam_su_smartcard_enforce.yaml
+++ b/rules/auth/auth_pam_su_smartcard_enforce.yaml
@@ -56,6 +56,10 @@ references:
       - 6.3
       - 6.4
       - 6.5
+  cmmc:
+    - IA.L2-3.5.3
+    - IA.L2-3.5.4
+    - TBD - 3.5.1e
 macOS:
   - "13.0"
 tags:
@@ -68,6 +72,8 @@ tags:
   - 800-171 
   - cnssi-1253
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: false
 mobileconfig_info:

--- a/rules/auth/auth_pam_sudo_smartcard_enforce.yaml
+++ b/rules/auth/auth_pam_sudo_smartcard_enforce.yaml
@@ -55,6 +55,10 @@ references:
       - 6.3
       - 6.4
       - 6.5
+  cmmc:
+    - IA.L2-3.5.3
+    - IA.L2-3.5.4
+    - TBD - 3.5.1e
 macOS:
   - "13.0"
 tags:
@@ -67,6 +71,8 @@ tags:
   - 800-171 
   - cnssi-1253
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: false
 mobileconfig_info:

--- a/rules/auth/auth_smartcard_allow.yaml
+++ b/rules/auth/auth_smartcard_allow.yaml
@@ -38,6 +38,10 @@ references:
       - 6.3
       - 6.4
       - 6.5
+  cmmc:
+    - IA.L1-3.5.1
+    - IA.L1-3.5.2
+    - IA.L2-3.5.3
 macOS:
   - "13.0"
 tags:
@@ -49,6 +53,9 @@ tags:
   - 800-53r4_high
   - cnssi-1253
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 mobileconfig: true
 mobileconfig_info:
   com.apple.security.smartcard:

--- a/rules/auth/auth_smartcard_certificate_trust_enforce_high.yaml
+++ b/rules/auth/auth_smartcard_certificate_trust_enforce_high.yaml
@@ -32,11 +32,15 @@ references:
     - N/A
   disa_stig:
     - N/A
+  cmmc:
+    - SC.L2-3.13.10
 macOS:
   - "13.0"
 tags:
   - 800-53r4_high
   - 800-53r5_high
+  - cmmc_lvl3
+  - cmmc_lvl2
 mobileconfig: true
 mobileconfig_info:
   com.apple.security.smartcard:

--- a/rules/auth/auth_smartcard_certificate_trust_enforce_moderate.yaml
+++ b/rules/auth/auth_smartcard_certificate_trust_enforce_moderate.yaml
@@ -32,12 +32,16 @@ references:
     - N/A
   disa_stig:
     - N/A
+  cmmc:
+    - SC.L2-3.13.10
 macOS:
   - "13.0"
 tags:
   - 800-53r4_moderate 
   - 800-53r5_moderate 
   - cnssi-1253
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/auth/auth_smartcard_enforce.yaml
+++ b/rules/auth/auth_smartcard_enforce.yaml
@@ -57,6 +57,12 @@ references:
       - 6.3
       - 6.4
       - 6.5
+  cmmc:
+    - IA.L1-3.5.1
+    - IA.L1-3.5.2
+    - IA.L2-3.5.3
+    - IA.L2-3.5.4
+    - TBD - 3.5.1e
 macOS:
   - "13.0"
 tags:
@@ -69,6 +75,9 @@ tags:
   - 800-171 
   - cnssi-1253
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 severity: "high"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/auth/auth_ssh_password_authentication_disable.yaml
+++ b/rules/auth/auth_ssh_password_authentication_disable.yaml
@@ -55,6 +55,13 @@ references:
       - 6.3
       - 6.4
       - 6.5
+  cmmc:
+    - IA.L1-3.5.1
+    - IA.L1-3.5.2
+    - IA.L2-3.5.3
+    - IA.L2-3.5.4
+    - MA.L2-3.7.5
+    - TBD - 3.5.1e
 macOS:
   - "13.0"
 tags:
@@ -67,5 +74,8 @@ tags:
   - 800-171 
   - cnssi-1253
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 mobileconfig: false
 mobileconfig_info:

--- a/rules/icloud/icloud_addressbook_disable.yaml
+++ b/rules/icloud/icloud_addressbook_disable.yaml
@@ -43,6 +43,10 @@ references:
       - 4.1
       - 4.8
       - 15.3
+  cmmc:
+    - AC.L1-3.1.20
+    - CM.L2-3.4.6
+    - CM.L2-3.4.7
 macOS:
   - "13.0"
 tags:
@@ -55,6 +59,9 @@ tags:
   - 800-171 
   - cnssi-1253
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 severity: "low"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/icloud/icloud_appleid_system_settings_disable.yaml
+++ b/rules/icloud/icloud_appleid_system_settings_disable.yaml
@@ -38,6 +38,10 @@ references:
     controls v8:
       - 4.1
       - 4.8
+  cmmc:
+    - AC.L1-3.1.20
+    - CM.L2-3.4.6
+    - CM.L2-3.4.7
 macOS:
   - "13.0"
 tags:
@@ -50,6 +54,9 @@ tags:
   - 800-171 
   - cnssi-1253
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 severity: "high"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/icloud/icloud_bookmarks_disable.yaml
+++ b/rules/icloud/icloud_bookmarks_disable.yaml
@@ -43,6 +43,10 @@ references:
       - 4.1
       - 4.8
       - 15.3
+  cmmc:
+    - AC.L1-3.1.20
+    - CM.L2-3.4.6
+    - CM.L2-3.4.7
 macOS:
   - "13.0"
 tags:
@@ -55,6 +59,9 @@ tags:
   - 800-171 
   - cnssi-1253
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/icloud/icloud_calendar_disable.yaml
+++ b/rules/icloud/icloud_calendar_disable.yaml
@@ -43,6 +43,10 @@ references:
       - 4.1
       - 4.8
       - 15.3
+  cmmc:
+    - AC.L1-3.1.20
+    - CM.L2-3.4.6
+    - CM.L2-3.4.7
 macOS:
   - "13.0"
 tags:
@@ -55,6 +59,9 @@ tags:
   - 800-171 
   - cnssi-1253
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 severity: "low"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/icloud/icloud_drive_disable.yaml
+++ b/rules/icloud/icloud_drive_disable.yaml
@@ -43,6 +43,10 @@ references:
       - 4.1
       - 4.8
       - 15.3
+  cmmc:
+    - AC.L1-3.1.20
+    - CM.L2-3.4.6
+    - CM.L2-3.4.7
 macOS:
   - "13.0"
 tags:
@@ -55,6 +59,9 @@ tags:
   - 800-171 
   - cnssi-1253
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/icloud/icloud_game_center_disable.yaml
+++ b/rules/icloud/icloud_game_center_disable.yaml
@@ -41,7 +41,11 @@ references:
     controls v8:
       - 4.1
       - 4.8
-      - 15.3    
+      - 15.3
+  cmmc:
+    - AC.L1-3.1.20
+    - CM.L2-3.4.6
+    - CM.L2-3.4.7
 macOS:
   - "13.0"
 tags:
@@ -54,6 +58,9 @@ tags:
   - 800-171
   - cisv8 
   - cnssi-1253
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/icloud/icloud_keychain_disable.yaml
+++ b/rules/icloud/icloud_keychain_disable.yaml
@@ -43,6 +43,10 @@ references:
       - 4.1
       - 4.8
       - 15.3
+  cmmc:
+    - AC.L1-3.1.20
+    - CM.L2-3.4.6
+    - CM.L2-3.4.7
 macOS:
   - "13.0"
 tags:
@@ -55,6 +59,9 @@ tags:
   - 800-171 
   - cnssi-1253
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/icloud/icloud_mail_disable.yaml
+++ b/rules/icloud/icloud_mail_disable.yaml
@@ -43,6 +43,10 @@ references:
       - 4.1
       - 4.8
       - 15.3
+  cmmc:
+    - AC.L1-3.1.20
+    - CM.L2-3.4.6
+    - CM.L2-3.4.7
 macOS:
   - "13.0"
 tags:
@@ -55,6 +59,9 @@ tags:
   - 800-171 
   - cnssi-1253
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 severity: "low"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/icloud/icloud_notes_disable.yaml
+++ b/rules/icloud/icloud_notes_disable.yaml
@@ -43,6 +43,10 @@ references:
       - 4.1
       - 4.8
       - 15.3
+  cmmc:
+    - AC.L1-3.1.20
+    - CM.L2-3.4.6
+    - CM.L2-3.4.7
 macOS:
   - "13.0"
 tags:
@@ -55,6 +59,9 @@ tags:
   - 800-171 
   - cnssi-1253
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 severity: "low"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/icloud/icloud_photos_disable.yaml
+++ b/rules/icloud/icloud_photos_disable.yaml
@@ -43,6 +43,10 @@ references:
       - 4.1
       - 4.8
       - 15.3
+  cmmc:
+    - AC.L1-3.1.20
+    - CM.L2-3.4.6
+    - CM.L2-3.4.7
 macOS:
   - "13.0"
 tags:
@@ -55,6 +59,9 @@ tags:
   - 800-171 
   - cnssi-1253
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/icloud/icloud_private_relay_disable.yaml
+++ b/rules/icloud/icloud_private_relay_disable.yaml
@@ -42,7 +42,11 @@ references:
     controls v8:
       - 4.1
       - 4.8
-      - 15.3    
+      - 15.3
+  cmmc:
+    - AC.L1-3.1.20
+    - CM.L2-3.4.6
+    - CM.L2-3.4.7
 macOS:
   - "13.0"
 tags:
@@ -54,6 +58,9 @@ tags:
   - 800-53r4_high 
   - 800-171 
   - cnssi-1253
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/icloud/icloud_reminders_disable.yaml
+++ b/rules/icloud/icloud_reminders_disable.yaml
@@ -43,6 +43,10 @@ references:
       - 4.1
       - 4.8
       - 15.3
+  cmmc:
+    - AC.L1-3.1.20
+    - CM.L2-3.4.6
+    - CM.L2-3.4.7
 macOS:
   - "13.0"
 tags:
@@ -55,6 +59,9 @@ tags:
   - 800-171 
   - cnssi-1253
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 severity: "low"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/icloud/icloud_sync_disable.yaml
+++ b/rules/icloud/icloud_sync_disable.yaml
@@ -43,6 +43,10 @@ references:
       - 4.1
       - 4.8
       - 15.3
+  cmmc:
+    - AC.L1-3.1.20
+    - CM.L2-3.4.6
+    - CM.L2-3.4.7
 macOS:
   - "13.0"
 tags:
@@ -56,6 +60,9 @@ tags:
   - cnssi-1253
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 mobileconfig: true
 mobileconfig_info:
   com.apple.applicationaccess:

--- a/rules/os/os_access_control_mobile_devices.yaml
+++ b/rules/os/os_access_control_mobile_devices.yaml
@@ -28,6 +28,8 @@ references:
       - N/A
     controls v8:
       - 6.4
+  cmmc:
+    - AC.L2-3.1.18
 macOS:
   - "13.0"
 tags:
@@ -36,5 +38,7 @@ tags:
   - 800-53r5_high
   - n_a
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 mobileconfig: false
 mobileconfig_info:

--- a/rules/os/os_airdrop_disable.yaml
+++ b/rules/os/os_airdrop_disable.yaml
@@ -45,6 +45,12 @@ references:
       - 4.1
       - 4.8
       - 6.7
+  cmmc:
+    - AC.L1-3.1.1
+    - AC.L1-3.1.20
+    - CM.L2-3.4.6
+    - CM.L2-3.4.7
+    - TBD - 3.14.3e
 macOS:
   - "13.0"
 tags:
@@ -59,6 +65,9 @@ tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/os/os_appleid_prompt_disable.yaml
+++ b/rules/os/os_appleid_prompt_disable.yaml
@@ -34,6 +34,8 @@ references:
     controls v8:
       - 4.1
       - 4.8
+  cmmc:
+    - AC.L1-3.1.20
 macOS:
   - "13.0"
 tags:
@@ -46,6 +48,9 @@ tags:
   - 800-171 
   - cnssi-1253
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/os/os_authenticated_root_enable.yaml
+++ b/rules/os/os_authenticated_root_enable.yaml
@@ -48,6 +48,12 @@ references:
     controls v8:
       - 3.6
       - 3.11
+  cmmc:
+    - AC.L1-3.1.1
+    - CM.L2-3.4.5
+    - SC.L2-3.13.11
+    - TBD - 3.14.1e
+    - TBD - 3.14.3e
 macOS:
   - "13.0"
 tags:
@@ -62,5 +68,8 @@ tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 mobileconfig: false
 mobileconfig_info:

--- a/rules/os/os_blank_bluray_disable.yaml
+++ b/rules/os/os_blank_bluray_disable.yaml
@@ -36,10 +36,16 @@ references:
     - N/A
   800-171r2:
     - 3.8.8
+  cmmc:
+    - MP.L2-3.8.7
+    - MP.L2-3.8.8
+    - TBD - 3.14.5e
 macOS:
   - "13.0"
 tags:
   - none
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/os/os_blank_cd_disable.yaml
+++ b/rules/os/os_blank_cd_disable.yaml
@@ -36,10 +36,16 @@ references:
     - N/A
   800-171r2:
     - 3.8.8
+  cmmc:
+    - MP.L2-3.8.7
+    - MP.L2-3.8.8
+    - TBD - 3.14.5e
 macOS:
   - "13.0"
 tags:
   - none
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/os/os_blank_dvd_disable.yaml
+++ b/rules/os/os_blank_dvd_disable.yaml
@@ -36,10 +36,16 @@ references:
     - N/A
   800-171r2:
     - 3.8.8
+  cmmc:
+    - MP.L2-3.8.7
+    - MP.L2-3.8.8
+    - TBD - 3.14.5e
 macOS:
   - "13.0"
 tags:
   - none
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/os/os_bluray_read_only_enforce.yaml
+++ b/rules/os/os_bluray_read_only_enforce.yaml
@@ -36,10 +36,16 @@ references:
     - N/A
   800-171r2:
     - 3.8.8
+  cmmc:
+    - MP.L2-3.8.7
+    - MP.L2-3.8.8
+    - TBD - 3.14.5e
 macOS:
   - "13.0"
 tags:
   - none
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/os/os_bonjour_disable.yaml
+++ b/rules/os/os_bonjour_disable.yaml
@@ -34,6 +34,9 @@ references:
     controls v8:
       - 4.1
       - 4.8
+  cmmc:
+    - CM.L2-3.4.6
+    - CM.L2-3.4.7
 macOS:
   - "13.0"
 tags:
@@ -47,6 +50,8 @@ tags:
   - cnssi-1253
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/os/os_burn_support_disable.yaml
+++ b/rules/os/os_burn_support_disable.yaml
@@ -26,10 +26,16 @@ references:
     - N/A
   disa_stig:
     - N/A
+  cmmc:
+    - MP.L2-3.8.7
+    - MP.L2-3.8.8
+    - TBD - 3.14.5e
 macOS:
   - "13.0"
 tags:
   - none
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "low"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/os/os_calendar_app_disable.yaml
+++ b/rules/os/os_calendar_app_disable.yaml
@@ -52,8 +52,12 @@ references:
     controls v8:
       - 4.1
       - 4.8
+  cmmc:
+    - AC.L1-3.1.20
+    - CM.L2-3.4.6
+    - CM.L2-3.4.7
 macOS:
-    - "13.0"
+  - "13.0"
 tags:
   - 800-53r5_low 
   - 800-53r5_moderate 
@@ -64,6 +68,9 @@ tags:
   - 800-171 
   - cnssi-1253
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/os/os_cd_read_only_enforce.yaml
+++ b/rules/os/os_cd_read_only_enforce.yaml
@@ -36,10 +36,16 @@ references:
     - N/A
   800-171r2:
     - 3.8.8
+  cmmc:
+    - MP.L2-3.8.7
+    - MP.L2-3.8.8
+    - TBD - 3.14.5e
 macOS:
   - "13.0"
 tags:
   - none
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/os/os_certificate_authority_trust.yaml
+++ b/rules/os/os_certificate_authority_trust.yaml
@@ -19,6 +19,8 @@ references:
     - SC-17
   disa_stig:
     - N/A
+  cmmc:
+    - SC.L2-3.13.10
 macOS:
   - "13.0"
 tags:
@@ -28,6 +30,8 @@ tags:
   - 800-53r4_high 
   - cnssi-1253 
   - manual
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "high"
 mobileconfig: false
 mobileconfig_info:

--- a/rules/os/os_config_data_install_enforce.yaml
+++ b/rules/os/os_config_data_install_enforce.yaml
@@ -42,6 +42,11 @@ references:
       - 7.3
       - 7.4
       - 7.7
+  cmmc:
+    - SI.L1-3.14.1
+    - SI.L1-3.14.2
+    - SI.L1-3.14.4
+    - TBD - 3.13.1e
 macOS:
   - "13.0"
 tags:
@@ -51,6 +56,9 @@ tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 severity: "high"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/os/os_config_profile_ui_install_disable.yaml
+++ b/rules/os/os_config_profile_ui_install_disable.yaml
@@ -25,6 +25,8 @@ references:
       - N/A
     controls v8:
       - N/A
+  cmmc:
+    - CM.L2-3.4.5
 macOS:
   - "13.0"
 tags:
@@ -32,6 +34,8 @@ tags:
   - 800-53r5_moderate 
   - 800-53r5_high
   - 800-171
+  - cmmc_lvl3
+  - cmmc_lvl2
 mobileconfig: true
 mobileconfig_info:
   com.apple.applicationaccess:

--- a/rules/os/os_disk_image_disable.yaml
+++ b/rules/os/os_disk_image_disable.yaml
@@ -36,10 +36,15 @@ references:
     - N/A
   800-171r2:
     - 3.8.8
+  cmmc:
+    - MP.L2-3.8.7
+    - MP.L2-3.8.8
+    - TBD - 3.14.5e
 macOS:
   - "13.0"
 tags:
-  - none
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/os/os_dvdram_disable.yaml
+++ b/rules/os/os_dvdram_disable.yaml
@@ -36,10 +36,16 @@ references:
     - N/A
   800-171r2:
     - 3.8.8
+  cmmc:
+    - MP.L2-3.8.7
+    - MP.L2-3.8.8
+    - TBD - 3.14.5e
 macOS:
   - "13.0"
 tags:
   - none
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/os/os_erase_content_and_settings_disable.yaml
+++ b/rules/os/os_erase_content_and_settings_disable.yaml
@@ -26,10 +26,15 @@ references:
     - N/A
   disa_stig:
     - N/A
+  cmmc:
+    - CM.L2-3.4.6
+    - CM.L2-3.4.7
 macOS:
   - "13.0"
 tags:
   - none
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/os/os_facetime_app_disable.yaml
+++ b/rules/os/os_facetime_app_disable.yaml
@@ -49,6 +49,10 @@ references:
     controls v8:
       - 4.1
       - 4.8
+  cmmc:
+    - AC.L1-3.1.20
+    - CM.L2-3.4.6
+    - CM.L2-3.4.7
 macOS:
   - "13.0"
 tags:
@@ -61,6 +65,9 @@ tags:
   - 800-171 
   - cnssi-1253
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 severity: "low"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/os/os_filevault_autologin_disable.yaml
+++ b/rules/os/os_filevault_autologin_disable.yaml
@@ -39,6 +39,9 @@ references:
     controls v8:
       - 3.3
       - 6.7
+  cmmc:
+    - AC.L1-3.1.1
+    - TBD - 3.14.3e
 macOS:
   - "13.0"
 tags:
@@ -51,6 +54,9 @@ tags:
   - 800-171 
   - cnssi-1253
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/os/os_firewall_default_deny_require.yaml
+++ b/rules/os/os_firewall_default_deny_require.yaml
@@ -37,6 +37,11 @@ references:
   800-171r2:
     - 3.1.3
     - 3.13.6
+  cmmc:
+    - AC.L2-3.1.3
+    - SC.L2-3.13.6
+    - TBD - 3.1.3e
+    - TBD - 3.14.3e
 macOS:
   - "13.0"
 tags:
@@ -46,5 +51,7 @@ tags:
   - 800-53r4_high
   - 800-171
   - cnssi-1253
+  - cmmc_lvl3
+  - cmmc_lvl2
 mobileconfig: false
 mobileconfig_info:

--- a/rules/os/os_firewall_log_enable.yaml
+++ b/rules/os/os_firewall_log_enable.yaml
@@ -52,6 +52,10 @@ references:
       - 4.5
       - 8.2
       - 8.5
+  cmmc:
+    - AU.L2-3.3.6
+    - SC.L1-3.13.1
+    - TBD - 3.13.4e
 macOS:
   - "13.0"
 tags:
@@ -66,6 +70,9 @@ tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 mobileconfig: true
 mobileconfig_info:
   com.apple.security.firewall:

--- a/rules/os/os_firmware_password_require.yaml
+++ b/rules/os/os_firmware_password_require.yaml
@@ -37,6 +37,10 @@ references:
     - N/A
   800-171r2:
     - 3.1.5
+  cmmc:
+    - AC.L1-3.1.1
+    - AC.L2-3.1.5
+    - TBD - 3.14.3e
 macOS:
   - "13.0"
 tags:
@@ -47,6 +51,9 @@ tags:
   - 800-171 
   - cnssi-1253
   - i386
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 severity: "medium"
 mobileconfig: false
 mobileconfig_info:

--- a/rules/os/os_gatekeeper_enable.yaml
+++ b/rules/os/os_gatekeeper_enable.yaml
@@ -44,6 +44,12 @@ references:
       - 10.1
       - 10.2
       - 10.5
+  cmmc:
+    - CM.L2-3.4.5
+    - SI.L1-3.14.1
+    - SI.L1-3.14.2
+    - SI.L1-3.14.4
+    - TBD - 3.13.1e
 macOS:
   - "13.0"
 tags:
@@ -57,6 +63,9 @@ tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 severity: "high"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/os/os_gatekeeper_rearm.yaml
+++ b/rules/os/os_gatekeeper_rearm.yaml
@@ -32,6 +32,11 @@ references:
       - N/A
     controls v8:
       - 10.5
+  cmmc:
+    - SI.L1-3.14.1
+    - SI.L1-3.14.2
+    - SI.L1-3.14.4
+    - CM.L2-3.4.5
 macOS:
   - "13.0"
 tags:
@@ -43,6 +48,9 @@ tags:
   - 800-171
   - cnssi-1253
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 mobileconfig: true
 mobileconfig_info:
   com.apple.ManagedClient.preferences:

--- a/rules/os/os_handoff_disable.yaml
+++ b/rules/os/os_handoff_disable.yaml
@@ -43,6 +43,12 @@ references:
     controls v8:
       - 4.1
       - 4.8
+  cmmc:
+    - AC.L1-3.1.1
+    - AC.L1-3.1.20
+    - CM.L2-3.4.6
+    - CM.L2-3.4.7
+    - TBD - 3.14.3e
 macOS:
   - "13.0"
 tags:
@@ -55,6 +61,9 @@ tags:
   - 800-171
   - cnssi-1253
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 severity: "low"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/os/os_home_folders_secure.yaml
+++ b/rules/os/os_home_folders_secure.yaml
@@ -37,6 +37,10 @@ references:
       - 5.1.1 (level 1)
     controls v8:
       - 3.3
+  cmmc:
+    - AC.L1-3.1.1
+    - AC.L2-3.1.5
+    - TBD - 3.14.3e
 macOS:
   - "13.0"
 tags:
@@ -48,6 +52,9 @@ tags:
   - cnssi-1253
   - cis_lvl1
   - cis_lvl2
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 severity: "medium"
 mobileconfig: false
 mobileconfig_info:

--- a/rules/os/os_httpd_disable.yaml
+++ b/rules/os/os_httpd_disable.yaml
@@ -36,6 +36,9 @@ references:
     controls v8:
       - 4.1
       - 4.8
+  cmmc:
+    - AC.L1-3.1.1
+    - TBD - 3.14.3e
 macOS:
   - "13.0"
 tags:
@@ -50,6 +53,9 @@ tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 severity: "medium"
 mobileconfig: false
 mobileconfig_info:

--- a/rules/os/os_icloud_storage_prompt_disable.yaml
+++ b/rules/os/os_icloud_storage_prompt_disable.yaml
@@ -34,6 +34,8 @@ references:
     controls v8:
       - 4.1
       - 4.8
+  cmmc:
+    - AC.L1-3.1.20
 macOS:
   - "13.0"
 tags:
@@ -46,6 +48,9 @@ tags:
   - 800-171 
   - cnssi-1253
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/os/os_implement_cryptography.yaml
+++ b/rules/os/os_implement_cryptography.yaml
@@ -29,6 +29,11 @@ references:
     - N/A
   800-171r2:
     - 3.13.11
+  cmmc:
+    - MP.L2-3.8.6
+    - SC.L2-3.13.11
+    - TBD - 3.14.1e
+    - TBD - 3.14.5e
 macOS:
   - "13.0"
 tags:
@@ -41,5 +46,7 @@ tags:
   - 800-171
   - cnssi-1253
   - inherent
+  - cmmc_lvl3
+  - cmmc_lvl2
 mobileconfig: false
 mobileconfig_info:

--- a/rules/os/os_install_log_retention_configure.yaml
+++ b/rules/os/os_install_log_retention_configure.yaml
@@ -36,6 +36,8 @@ references:
     controls v8:
       - 8.1
       - 8.3
+  cmmc:
+    - AU.L2-3.3.1
 macOS:
   - "13.0"
 odv:
@@ -47,5 +49,7 @@ tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 mobileconfig: false
 mobileconfig_info:

--- a/rules/os/os_ir_support_disable.yaml
+++ b/rules/os/os_ir_support_disable.yaml
@@ -42,6 +42,10 @@ references:
       - 4.1
       - 4.8
       - 12.6
+  cmmc:
+    - AC.L2-3.1.16
+    - CM.L2-3.4.6
+    - CM.L2-3.4.7
 macOS:
   - "13.0"
 tags:
@@ -54,6 +58,8 @@ tags:
   - 800-171
   - cnssi-1253
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 mobileconfig: true
 mobileconfig_info:
   com.apple.ManagedClient.preferences:

--- a/rules/os/os_logical_access.yaml
+++ b/rules/os/os_logical_access.yaml
@@ -32,6 +32,9 @@ references:
     controls v8:
       - 3.3
       - 6.7
+  cmmc:
+    - AC.L1-3.1.1
+    - TBD - 3.14.3e
 macOS:
   - "13.0"
 tags:
@@ -45,5 +48,8 @@ tags:
   - cnssi-1253
   - inherent
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 mobileconfig: false
 mobileconfig_info:

--- a/rules/os/os_mail_app_disable.yaml
+++ b/rules/os/os_mail_app_disable.yaml
@@ -54,6 +54,10 @@ references:
     controls v8:
       - 4.1
       - 4.8
+  cmmc:
+    - AC.L1-3.1.20
+    - CM.L2-3.4.6
+    - CM.L2-3.4.7
 macOS:
   - "13.0"
 tags:
@@ -66,6 +70,9 @@ tags:
   - 800-171 
   - cnssi-1253
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/os/os_malicious_code_prevention.yaml
+++ b/rules/os/os_malicious_code_prevention.yaml
@@ -52,6 +52,11 @@ references:
       - 10.1
       - 10.2
       - 10.5
+  cmmc:
+    - SI.L1-3.14.1
+    - SI.L1-3.14.2
+    - SI.L1-3.14.4
+    - TBD - 3.13.1e
 macOS:
   - "13.0"
 tags:
@@ -60,5 +65,8 @@ tags:
   - 800-53r5_moderate
   - 800-53r5_high
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 mobileconfig: false
 mobileconfig_info:

--- a/rules/os/os_managed_access_control_points.yaml
+++ b/rules/os/os_managed_access_control_points.yaml
@@ -23,11 +23,15 @@ references:
     - N/A
   srg:
     - N/A
+  cmmc:
+    - AC.L2-3.1.14
 macOS:
   - "13.0"
 tags:
   - 800-53r5_moderate
   - 800-53r5_high
   - n_a
+  - cmmc_lvl3
+  - cmmc_lvl2
 mobileconfig: false
 mobileconfig_info:

--- a/rules/os/os_mdm_require.yaml
+++ b/rules/os/os_mdm_require.yaml
@@ -48,6 +48,11 @@ references:
     controls v8:
       - 4.1
       - 5.1
+  cmmc:
+    - CM.L2-3.4.2
+    - TBD - 3.4.1e
+    - TBD - 3.4.2e
+    - TBD - 3.14.3e
 macOS:
   - "13.0"
 tags:
@@ -60,5 +65,7 @@ tags:
   - 800-171
   - cnssi-1253
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 mobileconfig: false
 mobileconfig_info:

--- a/rules/os/os_messages_app_disable.yaml
+++ b/rules/os/os_messages_app_disable.yaml
@@ -49,6 +49,10 @@ references:
     controls v8:
       - 4.1
       - 4.8
+  cmmc:
+    - AC.L1-3.1.20
+    - CM.L2-3.4.6
+    - CM.L2-3.4.7
 macOS:
   - "13.0"
 tags:
@@ -61,6 +65,9 @@ tags:
   - 800-171 
   - cnssi-1253
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 severity: "low"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/os/os_nfsd_disable.yaml
+++ b/rules/os/os_nfsd_disable.yaml
@@ -35,6 +35,9 @@ references:
     controls v8:
       - 4.1
       - 4.8
+  cmmc:
+    - AC.L1-3.1.1
+    - TBD - 3.14.3e
 macOS:
   - "13.0"
 tags:
@@ -49,6 +52,9 @@ tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 severity: "medium"
 mobileconfig: false
 mobileconfig_info:

--- a/rules/os/os_nonlocal_maintenance.yaml
+++ b/rules/os/os_nonlocal_maintenance.yaml
@@ -21,6 +21,8 @@ references:
     - N/A
   srg:
     - N/A
+  cmmc:
+    - MA.L2-3.7.5
 macOS:
   - "13.0"
 tags:
@@ -33,5 +35,7 @@ tags:
   - 800-171
   - cnssi-1253
   - n_a
+  - cmmc_lvl3
+  - cmmc_lvl2
 mobileconfig: false
 mobileconfig_info:

--- a/rules/os/os_notify_unauthorized_baseline_change.yaml
+++ b/rules/os/os_notify_unauthorized_baseline_change.yaml
@@ -23,9 +23,12 @@ references:
     - N/A
   srg:
     - N/A
+  cmmc:
+    - TBD - 3.4.2e
 macOS:
   - "13.0"
 tags:
   - permanent
+  - cmmc_lvl3
 mobileconfig: false
 mobileconfig_info:

--- a/rules/os/os_obscure_password.yaml
+++ b/rules/os/os_obscure_password.yaml
@@ -34,6 +34,10 @@ references:
       - N/A
     controls v8:
       - 4.1
+  cmmc:
+    - IA.L2-3.5.8
+    - IA.L2-3.5.9
+    - IA.L2-3.5.11
 macOS:
   - "13.0"
 tags:
@@ -47,5 +51,7 @@ tags:
   - cnssi-1253
   - inherent
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 mobileconfig: false
 mobileconfig_info:

--- a/rules/os/os_password_autofill_disable.yaml
+++ b/rules/os/os_password_autofill_disable.yaml
@@ -44,6 +44,11 @@ references:
     controls v8:
       - 4.1
       - 4.8
+  cmmc:
+    - CM.L2-3.4.6
+    - CM.L2-3.4.7
+    - IA.L2-3.5.8
+    - IA.L2-3.5.9
 macOS:
   - "13.0"
 tags:
@@ -56,6 +61,8 @@ tags:
   - 800-171
   - cnssi-1253
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 mobileconfig: true
 mobileconfig_info:
   com.apple.applicationaccess:

--- a/rules/os/os_password_hint_remove.yaml
+++ b/rules/os/os_password_hint_remove.yaml
@@ -29,11 +29,15 @@ references:
       - 2.11.1 (level 1)
     controls v8:
       - 5.2
+  cmmc:
+    - IA.L2-3.5.11
 macOS:
   - "13.0"
 tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 mobileconfig: false
 mobileconfig_info:

--- a/rules/os/os_password_proximity_disable.yaml
+++ b/rules/os/os_password_proximity_disable.yaml
@@ -35,6 +35,9 @@ references:
     controls v8:
       - 4.1
       - 4.8
+  cmmc:
+    - IA.L2-3.5.8
+    - IA.L2-3.5.9
 macOS:
   - "13.0"
 tags:
@@ -47,6 +50,8 @@ tags:
   - 800-171
   - cnssi-1253
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/os/os_password_sharing_disable.yaml
+++ b/rules/os/os_password_sharing_disable.yaml
@@ -33,6 +33,9 @@ references:
     controls v8:
       - 4.1
       - 4.8
+  cmmc:
+    - IA.L2-3.5.8
+    - IA.L2-3.5.9
 macOS:
   - "13.0"
 tags:
@@ -45,6 +48,8 @@ tags:
   - 800-171
   - cnssi-1253
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 mobileconfig: true
 mobileconfig_info:
   com.apple.applicationaccess:

--- a/rules/os/os_policy_banner_loginwindow_enforce.yaml
+++ b/rules/os/os_policy_banner_loginwindow_enforce.yaml
@@ -44,6 +44,8 @@ references:
       - 5.8 (level 2)
     controls v8:
       - 4.1
+  cmmc:
+    - AC.L2-3.1.9
 macOS:
   - "13.0"
 odv:
@@ -62,6 +64,8 @@ tags:
   - 800-171 
   - cnssi-1253
   - cis_lvl2
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: false
 mobileconfig_info:

--- a/rules/os/os_policy_banner_ssh_configure.yaml
+++ b/rules/os/os_policy_banner_ssh_configure.yaml
@@ -32,6 +32,8 @@ references:
     - N/A
   800-171r2:
     - 3.1.9
+  cmmc:
+    - AC.L2-3.1.9
 macOS:
   - "13.0"
 odv:
@@ -52,6 +54,8 @@ tags:
   - 800-53r4_high 
   - 800-171 
   - cnssi-1253
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: false
 mobileconfig_info:

--- a/rules/os/os_policy_banner_ssh_enforce.yaml
+++ b/rules/os/os_policy_banner_ssh_enforce.yaml
@@ -32,6 +32,8 @@ references:
     - N/A
   800-171r2:
     - 3.1.9
+  cmmc:
+    - AC.L2-3.1.9
 macOS:
   - "13.0"
 tags:
@@ -43,6 +45,8 @@ tags:
   - 800-53r4_high 
   - 800-171 
   - cnssi-1253
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: false
 mobileconfig_info:

--- a/rules/os/os_power_nap_disable.yaml
+++ b/rules/os/os_power_nap_disable.yaml
@@ -45,6 +45,9 @@ references:
     controls v8:
       - 4.1
       - 4.8
+  cmmc:
+    - CM.L2-3.4.6
+    - CM.L2-3.4.7
 macOS:
   - "13.0"
 tags:
@@ -52,5 +55,7 @@ tags:
   - cis_lvl2
   - cisv8
   - i386
+  - cmmc_lvl3
+  - cmmc_lvl2
 mobileconfig: false
 mobileconfig_info:

--- a/rules/os/os_prevent_priv_functions.yaml
+++ b/rules/os/os_prevent_priv_functions.yaml
@@ -27,6 +27,8 @@ references:
     - N/A
   800-171r2:
     - 3.1.7
+  cmmc:
+    - AC.L2-3.1.7
 macOS:
   - "13.0"
 tags:
@@ -37,5 +39,7 @@ tags:
   - 800-171
   - cnssi-1253
   - inherent
+  - cmmc_lvl3
+  - cmmc_lvl2
 mobileconfig: false
 mobileconfig_info:

--- a/rules/os/os_prevent_unauthorized_disclosure.yaml
+++ b/rules/os/os_prevent_unauthorized_disclosure.yaml
@@ -25,6 +25,8 @@ references:
     - N/A
   800-171r2:
     - 3.13.4
+  cmmc:
+    - SC.L2-3.13.4
 macOS:
   - "13.0"
 tags:
@@ -35,5 +37,7 @@ tags:
   - 800-171
   - cnssi-1253
   - inherent
+  - cmmc_lvl3
+  - cmmc_lvl2
 mobileconfig: false
 mobileconfig_info:

--- a/rules/os/os_privacy_setup_prompt_disable.yaml
+++ b/rules/os/os_privacy_setup_prompt_disable.yaml
@@ -34,10 +34,15 @@ references:
     controls v8:
       - 4.1
       - 4.8
+  cmmc:
+    - CM.L2-3.4.6
+    - CM.L2-3.4.7
 macOS:
   - "13.0"
 tags:
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/os/os_prohibit_remote_activation_collab_devices.yaml
+++ b/rules/os/os_prohibit_remote_activation_collab_devices.yaml
@@ -27,6 +27,8 @@ references:
     - N/A
   srg:
     - N/A
+  cmmc:
+    - SC.L2-3.13.12
 macOS:
   - "13.0"
 tags:
@@ -34,5 +36,7 @@ tags:
   - 800-53r5_low
   - 800-53r5_moderate
   - 800-53r5_high
+  - cmmc_lvl3
+  - cmmc_lvl2
 mobileconfig: false
 mobileconfig_info:

--- a/rules/os/os_rapid_security_response_allow.yaml
+++ b/rules/os/os_rapid_security_response_allow.yaml
@@ -33,6 +33,11 @@ references:
       - N/A
     controls v8:
       - N/A
+  cmmc:
+    - SI.L1-3.14.1
+    - SI.L1-3.14.2
+    - SI.L1-3.14.4
+    - TBD - 3.13.1e
 macOS:
   - "13.0"
 tags:
@@ -40,6 +45,9 @@ tags:
   - 800-53r5_moderate 
   - 800-53r5_high 
   - 800-171
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 mobileconfig: true
 mobileconfig_info:
   com.apple.applicationaccess:

--- a/rules/os/os_rapid_security_response_removal_disable.yaml
+++ b/rules/os/os_rapid_security_response_removal_disable.yaml
@@ -33,6 +33,11 @@ references:
       - N/A
     controls v8:
       - N/A
+  cmmc:
+    - SI.L1-3.14.1
+    - SI.L1-3.14.2
+    - SI.L1-3.14.4
+    - TBD - 3.13.1e
 macOS:
   - "13.0"
 tags:
@@ -40,6 +45,9 @@ tags:
   - 800-53r5_moderate 
   - 800-53r5_high 
   - 800-171
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 mobileconfig: true
 mobileconfig_info:
   com.apple.applicationaccess:

--- a/rules/os/os_recovery_lock_enable.yaml
+++ b/rules/os/os_recovery_lock_enable.yaml
@@ -27,6 +27,10 @@ references:
     - N/A
   800-171r2:
     - 3.1.5
+  cmmc:
+    - AC.L1-3.1.1
+    - AC.L2-3.1.5
+    - TBD - 3.14.3e
 macOS:
   - "13.0"
 tags:
@@ -38,6 +42,9 @@ tags:
   - cnssi-1253
   - arm64
   - manual
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 severity: "medium"
 mobileconfig: false
 mobileconfig_info:

--- a/rules/os/os_removable_media_disable.yaml
+++ b/rules/os/os_removable_media_disable.yaml
@@ -38,10 +38,16 @@ references:
     - N/A
   800-171r2:
     - 3.8.8
+  cmmc:
+    - MP.L2-3.8.7
+    - MP.L2-3.8.8
+    - TBD - 3.14.5e
 macOS:
   - "13.0"
 tags:
   - none
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/os/os_root_disable.yaml
+++ b/rules/os/os_root_disable.yaml
@@ -32,6 +32,9 @@ references:
       - 5.6 (level 1)
     controls v8:
       - 5.4
+  cmmc:
+    - IA.L1-3.5.1
+    - IA.L1-3.5.2
 macOS:
   - "13.0"
 tags:
@@ -46,5 +49,8 @@ tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 mobileconfig: false
 mobileconfig_info:

--- a/rules/os/os_separate_functionality.yaml
+++ b/rules/os/os_separate_functionality.yaml
@@ -28,6 +28,9 @@ references:
     - N/A
   800-171r2:
     - 3.13.3
+  cmmc:
+    - SC.L2-3.13.3
+    - TBD - 3.14.3e
 macOS:
   - "13.0"
 tags:
@@ -38,5 +41,7 @@ tags:
   - 800-171
   - cnssi-1253
   - inherent
+  - cmmc_lvl3
+  - cmmc_lvl2
 mobileconfig: false
 mobileconfig_info:

--- a/rules/os/os_sip_enable.yaml
+++ b/rules/os/os_sip_enable.yaml
@@ -58,6 +58,14 @@ references:
       - 2.3
       - 2.6
       - 10.5
+  cmmc:
+    - AC.L1-3.1.1
+    - AU.L2-3.3.8
+    - CM.L2-3.4.5
+    - SC.L2-3.13.4
+    - SI.L1-3.14.1
+    - SI.L1-3.14.4
+    - TBD - 3.14.3e
 macOS:
   - "13.0"
 tags:
@@ -72,6 +80,9 @@ tags:
   - cisv8
   - cis_lvl1
   - cis_lvl2
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 severity: "medium"
 mobileconfig: false
 mobileconfig_info:

--- a/rules/os/os_siri_prompt_disable.yaml
+++ b/rules/os/os_siri_prompt_disable.yaml
@@ -39,6 +39,10 @@ references:
     controls v8:
       - 4.1
       - 4.8
+  cmmc:
+    - AC.L1-3.1.20
+    - CM.L2-3.4.6
+    - CM.L2-3.4.7
 macOS:
   - "13.0"
 tags:
@@ -51,6 +55,9 @@ tags:
   - 800-171 
   - cnssi-1253
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/os/os_skip_screen_time_prompt_enable.yaml
+++ b/rules/os/os_skip_screen_time_prompt_enable.yaml
@@ -26,10 +26,14 @@ references:
     - N/A
   disa_stig:
     - N/A
+  cmmc:
+    - CM.L2-3.4.6
+    - CM.L2-3.4.7
 macOS:
   - "13.0"
 tags:
-  - none
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "low"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/os/os_skip_unlock_with_watch_enable.yaml
+++ b/rules/os/os_skip_unlock_with_watch_enable.yaml
@@ -32,7 +32,9 @@ references:
     benchmark:
       - N/A
     controls v8:
-      - 4.1    
+      - 4.1
+  cmmc:
+    - AC.L1-3.1.20
 macOS:
   - "13.0"
 tags:
@@ -45,6 +47,9 @@ tags:
   - 800-171 
   - cnssi-1253
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/os/os_ssh_fips_compliant.yaml
+++ b/rules/os/os_ssh_fips_compliant.yaml
@@ -56,6 +56,13 @@ references:
     - 3.1.13
     - 3.13.8
     - 3.13.11
+  cmmc:
+    - AC.L2-3.1.13
+    - MP.L2-3.8.6
+    - SC.L2-3.13.8
+    - SC.L2-3.13.11
+    - TBD - 3.14.1e
+    - TBD - 3.14.5e
 macOS:
   - "13.0"
 tags:
@@ -67,5 +74,7 @@ tags:
   - 800-53r4_high
   - 800-171
   - cnssi-1253
+  - cmmc_lvl3
+  - cmmc_lvl2
 mobileconfig: false
 mobileconfig_info:

--- a/rules/os/os_ssh_server_alive_count_max_configure.yaml
+++ b/rules/os/os_ssh_server_alive_count_max_configure.yaml
@@ -42,6 +42,8 @@ references:
     - N/A
   800-171r2:
     - 3.13.9
+  cmmc:
+    - SC.L2-3.13.9
 macOS:
   - "13.0"
 odv:
@@ -54,5 +56,7 @@ tags:
   - 800-53r4_high
   - 800-171
   - cnssi-1253
+  - cmmc_lvl3
+  - cmmc_lvl2
 mobileconfig: false
 mobileconfig_info:

--- a/rules/os/os_ssh_server_alive_interval_configure.yaml
+++ b/rules/os/os_ssh_server_alive_interval_configure.yaml
@@ -45,6 +45,9 @@ references:
     - N/A
   800-171r2:
     - 3.13.9
+  cmmc:
+    - AC.L2-3.1.11
+    - SC.L2-3.13.9
 macOS:
   - "13.0"
 odv:
@@ -57,5 +60,7 @@ tags:
   - 800-53r4_high
   - 800-171
   - cnssi-1253
+  - cmmc_lvl3
+  - cmmc_lvl2
 mobileconfig: false
 mobileconfig_info:

--- a/rules/os/os_sshd_client_alive_count_max_configure.yaml
+++ b/rules/os/os_sshd_client_alive_count_max_configure.yaml
@@ -44,6 +44,8 @@ references:
     - N/A
   800-171r2:
     - 3.13.9
+  cmmc:
+    - SC.L2-3.13.9
 macOS:
   - "13.0"
 odv:
@@ -56,6 +58,8 @@ tags:
   - 800-53r4_high
   - 800-171
   - cnssi-1253
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: false
 mobileconfig_info:

--- a/rules/os/os_sshd_client_alive_interval_configure.yaml
+++ b/rules/os/os_sshd_client_alive_interval_configure.yaml
@@ -47,6 +47,9 @@ references:
     - N/A
   800-171r2:
     - 3.13.9
+  cmmc:
+    - AC.L2-3.1.11
+    - SC.L2-3.13.9
 macOS:
   - "13.0"
 odv:
@@ -59,6 +62,8 @@ tags:
   - 800-53r4_high 
   - 800-171
   - cnssi-1253
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: false
 mobileconfig_info:

--- a/rules/os/os_sshd_fips_140_ciphers.yaml
+++ b/rules/os/os_sshd_fips_140_ciphers.yaml
@@ -57,10 +57,19 @@ references:
     - 3.1.13
     - 3.13.8
     - 3.13.11
+  cmmc:
+    - AC.L2-3.1.13
+    - MP.L2-3.8.6
+    - SC.L2-3.13.8
+    - SC.L2-3.13.11
+    - TBD - 3.14.1e
+    - TBD - 3.14.5e
 macOS:
   - "13.0"
 tags:
   - none
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: false
 mobileconfig_info:

--- a/rules/os/os_sshd_fips_140_macs.yaml
+++ b/rules/os/os_sshd_fips_140_macs.yaml
@@ -57,10 +57,19 @@ references:
     - 3.1.13
     - 3.13.8
     - 3.13.11
+  cmmc:
+    - AC.L2-3.1.13
+    - MP.L2-3.8.6
+    - SC.L2-3.13.8
+    - SC.L2-3.13.11
+    - TBD - 3.14.1e
+    - TBD - 3.14.5e
 macOS:
   - "13.0"
 tags:
   - none
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: false
 mobileconfig_info:

--- a/rules/os/os_sshd_fips_compliant.yaml
+++ b/rules/os/os_sshd_fips_compliant.yaml
@@ -67,6 +67,13 @@ references:
     - 3.1.13
     - 3.13.8
     - 3.13.11
+  cmmc:
+    - AC.L2-3.1.13
+    - MP.L2-3.8.6
+    - SC.L2-3.13.8
+    - SC.L2-3.13.11
+    - TBD - 3.14.1e
+    - TBD - 3.14.5e
 macOS:
   - "13.0"
 tags:
@@ -78,6 +85,8 @@ tags:
   - 800-53r4_high
   - 800-171
   - cnssi-1253
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: false
 mobileconfig_info:

--- a/rules/os/os_sshd_key_exchange_algorithm_configure.yaml
+++ b/rules/os/os_sshd_key_exchange_algorithm_configure.yaml
@@ -54,10 +54,14 @@ references:
     - N/A
   800-171r2:
     - N/A
+  cmmc:
+    - AC.L2-3.1.13
 macOS:
   - "13.0"
 tags:
   - none
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: false
 mobileconfig_info:

--- a/rules/os/os_sshd_login_grace_time_configure.yaml
+++ b/rules/os/os_sshd_login_grace_time_configure.yaml
@@ -44,6 +44,8 @@ references:
     - N/A
   800-171r2:
     - 3.13.9
+  cmmc:
+    - SC.L2-3.13.9
 macOS:
   - "13.0"
 odv:
@@ -51,6 +53,8 @@ odv:
   recommended: 30
 tags:
   - none
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: false
 mobileconfig_info:

--- a/rules/os/os_store_encrypted_passwords.yaml
+++ b/rules/os/os_store_encrypted_passwords.yaml
@@ -35,6 +35,10 @@ references:
       - N/A
     controls v8:
       - 3.11
+  cmmc:
+    - IA.L2-3.5.7
+    - IA.L2-3.5.8
+    - IA.L2-3.5.9
 macOS:
   - "13.0"
 tags:
@@ -48,5 +52,7 @@ tags:
   - cnssi-1253
   - inherent
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 mobileconfig: false
 mobileconfig_info:

--- a/rules/os/os_tftpd_disable.yaml
+++ b/rules/os/os_tftpd_disable.yaml
@@ -42,6 +42,12 @@ references:
       - 3.3
       - 3.1
       - 5.2
+  cmmc:
+    - AC.L1-3.1.1
+    - IA.L2-3.5.7
+    - IA.L2-3.5.8
+    - IA.L2-3.5.9
+    - TBD - 3.14.3e
 macOS:
   - "13.0"
 tags:
@@ -54,6 +60,9 @@ tags:
   - 800-171 
   - cnssi-1253
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 severity: "high"
 mobileconfig: false
 mobileconfig_info:

--- a/rules/os/os_time_server_enabled.yaml
+++ b/rules/os/os_time_server_enabled.yaml
@@ -34,6 +34,8 @@ references:
       - N/A
     controls v8:
       - 8.4
+  cmmc:
+    - AU.L2-3.3.7
 macOS:
   - "13.0"
 tags:
@@ -45,6 +47,8 @@ tags:
   - 800-53r4_moderate 
   - 800-53r4_high
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: false
 mobileconfig_info:

--- a/rules/os/os_touchid_prompt_disable.yaml
+++ b/rules/os/os_touchid_prompt_disable.yaml
@@ -34,6 +34,11 @@ references:
       - N/A
     controls v8:
       - 4.1
+  cmmc:
+    - CM.L2-3.4.2
+    - TBD - 3.4.1e
+    - TBD - 3.4.2e
+    - TBD - 3.14.3e
 macOS:
   - "13.0"
 tags:
@@ -46,6 +51,8 @@ tags:
   - 800-171
   - cnssi-1253
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/os/os_unique_identification.yaml
+++ b/rules/os/os_unique_identification.yaml
@@ -25,6 +25,8 @@ references:
     controls v8:
       - 5.1
       - 6.1
+  cmmc:
+    - IA.L2-3.5.5
 macOS:
   - "13.0"
 tags:
@@ -33,5 +35,7 @@ tags:
   - 800-53r5_high
   - inherent
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 mobileconfig: false
 mobileconfig_info:

--- a/rules/os/os_unlock_active_user_session_disable.yaml
+++ b/rules/os/os_unlock_active_user_session_disable.yaml
@@ -36,6 +36,9 @@ references:
       - 5.7 (level 1)
     controls v8:
       - 4.3
+  cmmc:
+    - IA.L1-3.5.1
+    - IA.L1-3.5.2
 macOS:
   - "13.0"
 tags:
@@ -50,5 +53,8 @@ tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 mobileconfig: false
 mobileconfig_info:

--- a/rules/os/os_user_app_installation_prohibit.yaml
+++ b/rules/os/os_user_app_installation_prohibit.yaml
@@ -36,10 +36,14 @@ references:
     - N/A
   disa_stig:
     - N/A
+  cmmc:
+    - CM.L2-3.4.9
 macOS:
   - "13.0"
 tags:
   - none
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/os/os_uucp_disable.yaml
+++ b/rules/os/os_uucp_disable.yaml
@@ -40,18 +40,24 @@ references:
       - 3.3
       - 4.1
       - 4.8
+  cmmc:
+    - AC.L1-3.1.1
+    - TBD - 3.14.3e
 macOS:
   - "13.0"
 tags:
-  - 800-53r5_low 
-  - 800-53r5_moderate 
-  - 800-53r5_high 
-  - 800-53r4_low 
-  - 800-53r4_moderate 
-  - 800-53r4_high 
-  - 800-171 
+  - 800-53r5_low
+  - 800-53r5_moderate
+  - 800-53r5_high
+  - 800-53r4_low
+  - 800-53r4_moderate
+  - 800-53r4_high
+  - 800-171
   - cnssi-1253
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 severity: "medium"
 mobileconfig: false
 mobileconfig_info:

--- a/rules/pwpolicy/pwpolicy_account_inactivity_enforce.yaml
+++ b/rules/pwpolicy/pwpolicy_account_inactivity_enforce.yaml
@@ -55,6 +55,8 @@ references:
       - N/A
     controls v8:
       - 5.3
+  cmmc:
+    - IA.L2-3.5.6
 macOS:
   - "13.0"
 odv:
@@ -69,5 +71,7 @@ tags:
   - 800-53r5_moderate
   - 800-53r5_high
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 mobileconfig: false
 mobileconfig_info:

--- a/rules/pwpolicy/pwpolicy_account_lockout_enforce.yaml
+++ b/rules/pwpolicy/pwpolicy_account_lockout_enforce.yaml
@@ -30,6 +30,8 @@ references:
       - 5.2.1 (level 1)
     controls v8:
       - 6.2
+  cmmc:
+    - AC.L2-3.1.8
 macOS:
   - "13.0"
 odv:
@@ -49,6 +51,8 @@ tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/pwpolicy/pwpolicy_account_lockout_timeout_enforce.yaml
+++ b/rules/pwpolicy/pwpolicy_account_lockout_timeout_enforce.yaml
@@ -30,6 +30,8 @@ references:
       - N/A
     controls v8:
       - 4.1
+  cmmc:
+    - AC.L2-3.1.8
 macOS:
   - "13.0"
 odv:
@@ -45,6 +47,8 @@ tags:
   - 800-53r5_moderate 
   - 800-53r5_high
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 \severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/pwpolicy/pwpolicy_alpha_numeric_enforce.yaml
+++ b/rules/pwpolicy/pwpolicy_alpha_numeric_enforce.yaml
@@ -39,6 +39,10 @@ references:
       - 5.2.4 (level 2)
     controls v8:
       - 5.2
+  cmmc:
+    - IA.L2-3.5.7
+    - IA.L2-3.5.8
+    - IA.L2-3.5.9
 macOS:
   - "13.0"
 tags:
@@ -52,6 +56,8 @@ tags:
   - 800-53r5_high
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/pwpolicy/pwpolicy_force_password_change.yaml
+++ b/rules/pwpolicy/pwpolicy_force_password_change.yaml
@@ -41,6 +41,10 @@ references:
       - N/A
     controls v8:
       - 5.2
+  cmmc:
+    - IA.L2-3.5.7
+    - IA.L2-3.5.8
+    - IA.L2-3.5.9
 macOS:
   - "13.0"
 tags:
@@ -54,5 +58,7 @@ tags:
   - 800-53r5_high
   - inherent
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 mobileconfig: false
 mobileconfig_info:

--- a/rules/pwpolicy/pwpolicy_history_enforce.yaml
+++ b/rules/pwpolicy/pwpolicy_history_enforce.yaml
@@ -37,6 +37,10 @@ references:
       - 5.2.8 (level 1)
     controls v8:
       - 5.2
+  cmmc:
+    - IA.L2-3.5.7
+    - IA.L2-3.5.8
+    - IA.L2-3.5.9
 macOS:
   - "13.0"
 odv: 
@@ -56,6 +60,8 @@ tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/pwpolicy/pwpolicy_lower_case_character_enforce.yaml
+++ b/rules/pwpolicy/pwpolicy_lower_case_character_enforce.yaml
@@ -62,6 +62,10 @@ references:
       - 5.2.6 (level 2)
     controls v8:
       - 5.2
+  cmmc:
+    - IA.L2-3.5.7
+    - IA.L2-3.5.8
+    - IA.L2-3.5.9
 macOS:
   - "13.0"
 odv:
@@ -79,5 +83,7 @@ tags:
   - 800-53r5_high
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 mobileconfig: false
 mobileconfig_info:

--- a/rules/pwpolicy/pwpolicy_max_lifetime_enforce.yaml
+++ b/rules/pwpolicy/pwpolicy_max_lifetime_enforce.yaml
@@ -38,6 +38,9 @@ references:
       - 5.2.7 (level 1)
     controls v8:
       - 5.3
+  cmmc:
+    - IA.L2-3.5.8
+    - IA.L2-3.5.9
 macOS:
   - "13.0"
 odv:
@@ -57,6 +60,8 @@ tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/pwpolicy/pwpolicy_minimum_length_enforce.yaml
+++ b/rules/pwpolicy/pwpolicy_minimum_length_enforce.yaml
@@ -38,6 +38,10 @@ references:
       - 5.2.2 (level 1)
     controls v8:
       - 5.2
+  cmmc:
+    - IA.L2-3.5.7
+    - IA.L2-3.5.8
+    - IA.L2-3.5.9
 macOS:
   - "13.0"
 odv:
@@ -57,6 +61,8 @@ tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/pwpolicy/pwpolicy_minimum_lifetime_enforce.yaml
+++ b/rules/pwpolicy/pwpolicy_minimum_lifetime_enforce.yaml
@@ -59,6 +59,9 @@ references:
       - N/A
     controls v8:
       - 4.7
+  cmmc:
+    - IA.L2-3.5.8
+    - IA.L2-3.5.9
 macOS:
   - "13.0"
 odv:
@@ -74,5 +77,7 @@ tags:
   - 800-53r5_moderate
   - 800-53r5_high
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 mobileconfig: false
 mobileconfig_info:

--- a/rules/pwpolicy/pwpolicy_simple_sequence_disable.yaml
+++ b/rules/pwpolicy/pwpolicy_simple_sequence_disable.yaml
@@ -38,6 +38,10 @@ references:
       - N/A
     controls v8:
       - 5.2
+  cmmc:
+    - IA.L2-3.5.7
+    - IA.L2-3.5.8
+    - IA.L2-3.5.9
 macOS:
   - "13.0"
 tags:
@@ -50,6 +54,8 @@ tags:
   - 800-53r5_moderate
   - 800-53r5_high 
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 mobileconfig: true
 mobileconfig_info:
   com.apple.mobiledevice.passwordpolicy:

--- a/rules/pwpolicy/pwpolicy_special_character_enforce.yaml
+++ b/rules/pwpolicy/pwpolicy_special_character_enforce.yaml
@@ -40,6 +40,10 @@ references:
       - 5.2.5 (level 2)
     controls v8:
       - 5.2
+  cmmc:
+    - IA.L2-3.5.7
+    - IA.L2-3.5.8
+    - IA.L2-3.5.9
 macOS:
   - "13.0"
 odv:
@@ -57,6 +61,8 @@ tags:
   - 800-53r5_high
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/pwpolicy/pwpolicy_upper_case_character_enforce.yaml
+++ b/rules/pwpolicy/pwpolicy_upper_case_character_enforce.yaml
@@ -62,6 +62,10 @@ references:
       - 5.2.6 (level 2)
     controls v8:
       - 5.2
+  cmmc:
+    - IA.L2-3.5.7
+    - IA.L2-3.5.8
+    - IA.L2-3.5.9
 macOS:
   - "13.0"
 tags:
@@ -75,5 +79,7 @@ tags:
   - 800-53r5_high
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 mobileconfig: false
 mobileconfig_info:

--- a/rules/supplemental/supplemental_controls.yaml
+++ b/rules/supplemental/supplemental_controls.yaml
@@ -189,6 +189,8 @@ references:
     - N/A
   disa_stig:
     - N/A
+  cmmc:
+    - N/A
 macOS:
   - "13.0"
 tags:

--- a/rules/supplemental/supplemental_filevault.yaml
+++ b/rules/supplemental/supplemental_filevault.yaml
@@ -65,6 +65,8 @@ references:
     - N/A
   disa_stig:
     - N/A
+  cmmc:
+    - N/A
 macOS:
   - "13.0"
 tags:

--- a/rules/supplemental/supplemental_firewall_pf.yaml
+++ b/rules/supplemental/supplemental_firewall_pf.yaml
@@ -114,6 +114,8 @@ references:
     - N/A
   disa_stig:
     - N/A
+  cmmc:
+    - N/A
 macOS:
   - "13.0"
 tags:

--- a/rules/supplemental/supplemental_password_policy.yaml
+++ b/rules/supplemental/supplemental_password_policy.yaml
@@ -46,6 +46,8 @@ references:
     - N/A
   disa_stig:
     - N/A
+  cmmc:
+    - N/A
 macOS:
   - "13.0"
 tags:

--- a/rules/supplemental/supplemental_smartcard.yaml
+++ b/rules/supplemental/supplemental_smartcard.yaml
@@ -299,6 +299,8 @@ references:
     - N/A
   disa_stig:
     - N/A
+  cmmc:
+    - N/A
 macOS:
   - "13.0"
 tags:

--- a/rules/system_settings/system_settings_USB_restricted_mode.yaml
+++ b/rules/system_settings/system_settings_USB_restricted_mode.yaml
@@ -31,12 +31,18 @@ references:
       - N/A
     controls v8:
       - N/A
+  cmmc:
+    - MP.L2-3.8.7
+    - MP.L2-3.8.8
+    - TBD - 3.14.5e
 macOS:
   - "13.0"
 tags:
   - 800-53r5_low
   - 800-53r5_moderate
   - 800-53r5_high
+  - cmmc_lvl3
+  - cmmc_lvl2
 mobileconfig: true
 mobileconfig_info:
   com.apple.applicationaccess:

--- a/rules/system_settings/system_settings_airplay_receiver_disable.yaml
+++ b/rules/system_settings/system_settings_airplay_receiver_disable.yaml
@@ -36,7 +36,10 @@ references:
       - 2.3.1.2 (level 1)
     controls v8:
       - 4.1
-      - 4.8 
+      - 4.8
+  cmmc:
+    - CM.L2-3.4.6
+    - CM.L2-3.4.7
 macOS:
   - "13.0"
 tags:
@@ -45,7 +48,9 @@ tags:
   - 800-53r5_high
   - cis_lvl1
   - cis_lvl2
-  - cisv8  
+  - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 mobileconfig: true
 mobileconfig_info:
   com.apple.applicationaccess:

--- a/rules/system_settings/system_settings_apple_watch_unlock_disable.yaml
+++ b/rules/system_settings/system_settings_apple_watch_unlock_disable.yaml
@@ -28,6 +28,8 @@ references:
     - N/A
   800-171r2:
     - 3.1.10
+  cmmc:
+    - AC.L2-3.1.10
 macOS:
   - "13.0"
 tags:
@@ -37,6 +39,8 @@ tags:
   - 800-53r4_high 
   - 800-171 
   - cnssi-1253
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/system_settings/system_settings_automatic_login_disable.yaml
+++ b/rules/system_settings/system_settings_automatic_login_disable.yaml
@@ -36,6 +36,9 @@ references:
       - 2.12.3 (level 1)
     controls v8:
       - 4.7
+  cmmc:
+    - IA.L1-3.5.1
+    - IA.L1-3.5.2
 macOS:
   - "13.0"
 tags:
@@ -50,6 +53,9 @@ tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/system_settings/system_settings_automatic_logout_enforce.yaml
+++ b/rules/system_settings/system_settings_automatic_logout_enforce.yaml
@@ -34,6 +34,9 @@ references:
     - N/A
   800-171r2:
     - 3.1.11
+  cmmc:
+    - AC.L2-3.1.10
+    - AC.L2-3.1.11
 macOS:
   - "13.0"
 odv:
@@ -46,6 +49,8 @@ tags:
   - 800-53r4_high
   - 800-171
   - cnssi-1253
+  - cmmc_lvl3
+  - cmmc_lvl2
 mobileconfig: true
 mobileconfig_info:
   .GlobalPreferences:

--- a/rules/system_settings/system_settings_bluetooth_disable.yaml
+++ b/rules/system_settings/system_settings_bluetooth_disable.yaml
@@ -41,6 +41,8 @@ references:
       - 4.8
       - 12.6
       - 13.9
+  cmmc:
+    - AC.L2-3.1.16
 macOS:
   - "13.0"
 tags:
@@ -52,6 +54,8 @@ tags:
   - 800-171 
   - cnssi-1253
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "low"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/system_settings/system_settings_bluetooth_sharing_disable.yaml
+++ b/rules/system_settings/system_settings_bluetooth_sharing_disable.yaml
@@ -52,6 +52,11 @@ references:
     controls v8:
       - 3.3
       - 4.1
+  cmmc:
+    - AC.L1-3.1.1
+    - CM.L2-3.4.6
+    - CM.L2-3.4.7
+    - TBD - 3.14.3e
 macOS:
   - "13.0"
 tags:
@@ -66,6 +71,9 @@ tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 mobileconfig: false
 mobileconfig_info:
 

--- a/rules/system_settings/system_settings_cd_dvd_sharing_disable.yaml
+++ b/rules/system_settings/system_settings_cd_dvd_sharing_disable.yaml
@@ -34,6 +34,9 @@ references:
     controls v8:
       - 4.1
       - 4.8
+  cmmc:
+    - CM.L2-3.4.6
+    - CM.L2-3.4.7
 macOS:
   - "13.0"
 tags:
@@ -47,6 +50,8 @@ tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 mobileconfig: false
 mobileconfig_info:
 

--- a/rules/system_settings/system_settings_content_caching_disable.yaml
+++ b/rules/system_settings/system_settings_content_caching_disable.yaml
@@ -35,6 +35,9 @@ references:
       - 2.3.3.9 (level 2)
     controls v8:
       - 4.8
+  cmmc:
+    - CM.L2-3.4.6
+    - CM.L2-3.4.7
 macOS:
   - "13.0"
 tags:
@@ -48,6 +51,8 @@ tags:
   - cnssi-1253
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 mobileconfig: true
 mobileconfig_info:
   com.apple.applicationaccess:

--- a/rules/system_settings/system_settings_critical_update_install_enforce.yaml
+++ b/rules/system_settings/system_settings_critical_update_install_enforce.yaml
@@ -33,6 +33,9 @@ references:
       - 7.3
       - 7.4
       - 7.7
+  cmmc:
+    - SI.L1-3.14.1
+    - SI.L1-3.14.4
 macOS:
   - "13.0"
 tags:
@@ -42,6 +45,9 @@ tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 mobileconfig: true
 mobileconfig_info:
   com.apple.SoftwareUpdate:

--- a/rules/system_settings/system_settings_diagnostics_reports_disable.yaml
+++ b/rules/system_settings/system_settings_diagnostics_reports_disable.yaml
@@ -46,6 +46,8 @@ references:
     controls v8: 
       - 4.1
       - 4.8
+  cmmc:
+    - AC.L1-3.1.20
 macOS:
   - "13.0"
 tags:
@@ -59,6 +61,9 @@ tags:
   - cnssi-1253
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/system_settings/system_settings_filevault_enforce.yaml
+++ b/rules/system_settings/system_settings_filevault_enforce.yaml
@@ -33,6 +33,8 @@ references:
     controls v8: 
       - 3.6
       - 3.11
+  cmmc:
+    - SC.L2-3.13.16
 macOS:
   - "13.0"
 tags:
@@ -45,6 +47,8 @@ tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: false
 mobileconfig_info:

--- a/rules/system_settings/system_settings_find_my_disable.yaml
+++ b/rules/system_settings/system_settings_find_my_disable.yaml
@@ -53,6 +53,10 @@ references:
       - 4.1
       - 4.8
       - 15.3
+  cmmc:
+    - AC.L1-3.1.20
+    - CM.L2-3.4.6
+    - CM.L2-3.4.7
 macOS:
   - "13.0"
 tags:
@@ -65,6 +69,9 @@ tags:
   - 800-171
   - cnssi-1253
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 mobileconfig: true
 mobileconfig_info:
   com.apple.applicationaccess:

--- a/rules/system_settings/system_settings_firewall_enable.yaml
+++ b/rules/system_settings/system_settings_firewall_enable.yaml
@@ -51,6 +51,14 @@ references:
       - 4.1
       - 4.5
       - 13.1
+  cmmc:
+    - AC.L2-3.1.3
+    - CM.L2-3.4.6
+    - CM.L2-3.4.7
+    - SC.L1-3.13.1
+    - TBD - 3.1.3e
+    - TBD - 3.13.4e
+    - TBD - 3.14.3e
 macOS:
   - "13.0"
 tags:
@@ -65,6 +73,9 @@ tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/system_settings/system_settings_firewall_stealth_mode_enable.yaml
+++ b/rules/system_settings/system_settings_firewall_stealth_mode_enable.yaml
@@ -47,6 +47,11 @@ references:
       - 4.1
       - 4.5
       - 4.8
+  cmmc:
+    - CM.L2-3.4.6
+    - CM.L2-3.4.7
+    - SC.L1-3.13.1
+    - TBD - 3.13.4e
 macOS:
   - "13.0"
 tags:
@@ -61,6 +66,9 @@ tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/system_settings/system_settings_gatekeeper_identified_developers_allowed.yaml
+++ b/rules/system_settings/system_settings_gatekeeper_identified_developers_allowed.yaml
@@ -33,6 +33,8 @@ references:
     - N/A
   800-171r2:
     - 3.4.5
+  cmmc:
+    - CM.L2-3.4.5
 macOS:
   - "13.0"
 tags:
@@ -43,6 +45,8 @@ tags:
   - 800-53r4_high 
   - 800-171 
   - cnssi-1253
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/system_settings/system_settings_gatekeeper_override_disallow.yaml
+++ b/rules/system_settings/system_settings_gatekeeper_override_disallow.yaml
@@ -30,6 +30,8 @@ references:
     - N/A
   800-171r2:
     - 3.4.5
+  cmmc:
+    - CM.L2-3.4.5
 macOS:
   - "13.0"
 tags:
@@ -40,6 +42,8 @@ tags:
   - 800-53r4_high 
   - 800-171 
   - cnssi-1253
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/system_settings/system_settings_guest_access_smb_disable.yaml
+++ b/rules/system_settings/system_settings_guest_access_smb_disable.yaml
@@ -36,6 +36,8 @@ references:
       - 2.12.2 (level 1)
     controls v8: 
       - 3.3
+  cmmc:
+    - AC.L1-3.1.2
 macOS:
   - "13.0"
 tags:
@@ -50,5 +52,8 @@ tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 mobileconfig: false
 mobileconfig_info:

--- a/rules/system_settings/system_settings_guest_account_disable.yaml
+++ b/rules/system_settings/system_settings_guest_account_disable.yaml
@@ -38,6 +38,8 @@ references:
       - 5.2
       - 6.2
       - 6.8
+  cmmc:
+    - AC.L1-3.1.2
 macOS:
   - "13.0"
 tags:
@@ -52,6 +54,9 @@ tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 severity: "high"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/system_settings/system_settings_improve_siri_dictation_disable.yaml
+++ b/rules/system_settings/system_settings_improve_siri_dictation_disable.yaml
@@ -37,6 +37,10 @@ references:
     controls v8:
       - 4.1
       - 4.8
+  cmmc:
+    - AC.L1-3.1.20
+    - CM.L2-3.4.6
+    - CM.L2-3.4.7
 macOS:
   - "13.0"
 tags:
@@ -49,6 +53,9 @@ tags:
   - 800-171
   - cnssi-1253
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 mobileconfig: true
 mobileconfig_info:
   com.apple.assistant.support:

--- a/rules/system_settings/system_settings_internet_accounts_disable.yaml
+++ b/rules/system_settings/system_settings_internet_accounts_disable.yaml
@@ -36,6 +36,9 @@ references:
     controls v8:
       - 4.8
       - 15.2
+  cmmc:
+    - AC.L1-3.1.20
+    - CM.L2-3.4.8
 macOS:
   - "13.0"
 tags:
@@ -48,6 +51,9 @@ tags:
   - 800-171 
   - cnssi-1253
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/system_settings/system_settings_internet_sharing_disable.yaml
+++ b/rules/system_settings/system_settings_internet_sharing_disable.yaml
@@ -37,6 +37,11 @@ references:
     controls v8: 
       - 4.1
       - 4.8
+  cmmc:
+    - AC.L1-3.1.20
+    - AC.L2-3.1.3
+    - TBD - 3.1.3e
+    - TBD - 3.14.3e
 macOS:
   - "13.0"
 tags:
@@ -51,6 +56,9 @@ tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/system_settings/system_settings_location_services_disable.yaml
+++ b/rules/system_settings/system_settings_location_services_disable.yaml
@@ -34,6 +34,9 @@ references:
     - N/A
   800-171r2:
     - 3.4.6
+  cmmc:
+    - CM.L2-3.4.6
+    - CM.L2-3.4.7
 macOS:
   - "13.0"
 tags:
@@ -45,6 +48,8 @@ tags:
   - 800-53r4_high 
   - 800-171 
   - cnssi-1253
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: false
 mobileconfig_info:

--- a/rules/system_settings/system_settings_loginwindow_prompt_username_password_enforce.yaml
+++ b/rules/system_settings/system_settings_loginwindow_prompt_username_password_enforce.yaml
@@ -34,6 +34,9 @@ references:
       - 2.10.4 (level 1)
     controls v8: 
       - 4.1
+  cmmc:
+    - IA.L1-3.5.1
+    - IA.L1-3.5.2
 macOS:
   - "13.0"
 tags:
@@ -48,7 +51,10 @@ tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
-severity: "low"  
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
+severity: "low"
 mobileconfig: true
 mobileconfig_info:
   com.apple.loginwindow:

--- a/rules/system_settings/system_settings_media_sharing_disabled.yaml
+++ b/rules/system_settings/system_settings_media_sharing_disabled.yaml
@@ -51,6 +51,9 @@ references:
     controls v8:
       - 4.1
       - 4.8
+  cmmc:
+    - AC.L1-3.1.1
+    - TBD - 3.14.3e
 macOS:
   - "13.0"
 tags:
@@ -63,6 +66,9 @@ tags:
   - 800-171
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 mobileconfig: true
 mobileconfig_info:
   com.apple.preferences.sharing.SharingPrefsExtension:

--- a/rules/system_settings/system_settings_password_hints_disable.yaml
+++ b/rules/system_settings/system_settings_password_hints_disable.yaml
@@ -33,6 +33,8 @@ references:
       - 2.10.5 (level 1)
     controls v8:
       - 4.1
+  cmmc:
+    - IA.L2-3.5.11
 macOS:
   - "13.0"
 tags:
@@ -47,6 +49,8 @@ tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/system_settings/system_settings_personalized_advertising_disable.yaml
+++ b/rules/system_settings/system_settings_personalized_advertising_disable.yaml
@@ -39,6 +39,10 @@ references:
       - 2.6.3 (level 1)
     controls v8:
       - 4.8
+  cmmc:
+    - AC.L1-3.1.20
+    - CM.L2-3.4.6
+    - CM.L2-3.4.7
 macOS:
   - "13.0"
 tags:
@@ -53,6 +57,9 @@ tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 mobileconfig: true
 mobileconfig_info:
   com.apple.applicationaccess:

--- a/rules/system_settings/system_settings_printer_sharing_disable.yaml
+++ b/rules/system_settings/system_settings_printer_sharing_disable.yaml
@@ -35,6 +35,9 @@ references:
     controls v8:
       - 4.1
       - 4.8
+  cmmc:
+    - CM.L2-3.4.6
+    - CM.L2-3.4.7
 macOS:
   - "13.0"
 tags:
@@ -47,6 +50,8 @@ tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 mobileconfig: false
 mobileconfig_info:
 

--- a/rules/system_settings/system_settings_rae_disable.yaml
+++ b/rules/system_settings/system_settings_rae_disable.yaml
@@ -38,6 +38,9 @@ references:
     controls v8:
       - 4.1
       - 4.8
+  cmmc:
+    - AC.L1-3.1.1
+    - TBD - 3.14.3e
 macOS:
   - "13.0"
 tags:
@@ -52,6 +55,9 @@ tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 severity: "medium"
 mobileconfig: false
 mobileconfig_info:

--- a/rules/system_settings/system_settings_remote_management_disable.yaml
+++ b/rules/system_settings/system_settings_remote_management_disable.yaml
@@ -35,6 +35,9 @@ references:
       - 4.1
       - 4.8
       - 5.4
+  cmmc:
+    - CM.L2-3.4.6
+    - CM.L2-3.4.7
 macOS:
   - "13.0"
 tags:
@@ -48,5 +51,7 @@ tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 mobileconfig: false
 mobileconfig_info:

--- a/rules/system_settings/system_settings_screen_sharing_disable.yaml
+++ b/rules/system_settings/system_settings_screen_sharing_disable.yaml
@@ -38,6 +38,9 @@ references:
     controls v8:
       - 4.1
       - 4.8
+  cmmc:
+    - AC.L1-3.1.1
+    - TBD - 3.14.3e
 macOS:
   - "13.0"
 tags:
@@ -52,6 +55,9 @@ tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 severity: "medium"
 mobileconfig: false
 mobileconfig_info:

--- a/rules/system_settings/system_settings_screensaver_ask_for_password_delay_enforce.yaml
+++ b/rules/system_settings/system_settings_screensaver_ask_for_password_delay_enforce.yaml
@@ -40,6 +40,8 @@ references:
       - 2.10.2 (level 1)
     controls v8:
       - 4.7
+  cmmc:
+    - AC.L2-3.1.10
 macOS:
   - "13.0"
 odv:
@@ -57,6 +59,8 @@ tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/system_settings/system_settings_screensaver_password_enforce.yaml
+++ b/rules/system_settings/system_settings_screensaver_password_enforce.yaml
@@ -28,6 +28,8 @@ references:
     - N/A
   800-171r2:
     - 3.1.10
+  cmmc:
+    - AC.L2-3.1.10
 macOS:
   - "13.0"
 tags:
@@ -37,6 +39,8 @@ tags:
   - 800-53r4_high 
   - 800-171 
   - cnssi-1253
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/system_settings/system_settings_screensaver_timeout_enforce.yaml
+++ b/rules/system_settings/system_settings_screensaver_timeout_enforce.yaml
@@ -41,6 +41,8 @@ references:
       - 2.10.1 (level 1)
     controls v8:
       - 4.3
+  cmmc:
+    - AC.L2-3.1.10
 macOS:
   - "13.0"
 odv: 
@@ -59,6 +61,8 @@ tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/system_settings/system_settings_siri_disable.yaml
+++ b/rules/system_settings/system_settings_siri_disable.yaml
@@ -40,6 +40,10 @@ references:
     controls v8:
       - 4.1
       - 4.8
+  cmmc:
+    - AC.L1-3.1.20
+    - CM.L2-3.4.6
+    - CM.L2-3.4.7
 macOS:
   - "13.0"
 tags:
@@ -52,6 +56,9 @@ tags:
   - 800-171 
   - cnssi-1253
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/system_settings/system_settings_smbd_disable.yaml
+++ b/rules/system_settings/system_settings_smbd_disable.yaml
@@ -38,6 +38,9 @@ references:
       - 4.1
       - 4.8
       - 5.4
+  cmmc:
+    - AC.L1-3.1.1
+    - TBD - 3.14.3e
 macOS:
   - "13.0"
 tags:
@@ -52,6 +55,9 @@ tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 severity: "medium"
 mobileconfig: false
 mobileconfig_info:

--- a/rules/system_settings/system_settings_ssh_disable.yaml
+++ b/rules/system_settings/system_settings_ssh_disable.yaml
@@ -42,12 +42,19 @@ references:
     controls v8:
       - 4.1
       - 4.8
+  cmmc:
+    - AC.L1-3.1.1
+    - CM.L2-3.4.6
+    - CM.L2-3.4.7
 macOS:
   - "13.0"
 tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 severity: "medium"
 mobileconfig: false
 mobileconfig_info:

--- a/rules/system_settings/system_settings_ssh_enable.yaml
+++ b/rules/system_settings/system_settings_ssh_enable.yaml
@@ -37,6 +37,13 @@ references:
     - 3.1.2
     - 3.4.6
     - 3.5.4
+  cmmc:
+    - AC.L1-3.1.1
+    - CM.L2-3.4.6
+    - CM.L2-3.4.7
+    - IA.L2-3.5.4
+    - TBD - 3.5.1e
+    - TBD - 3.14.3e
 macOS:
   - "13.0"
 tags:
@@ -48,5 +55,8 @@ tags:
   - 800-53r4_high 
   - 800-171 
   - cnssi-1253
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 mobileconfig: false
 mobileconfig_info:

--- a/rules/system_settings/system_settings_system_wide_preferences_configure.yaml
+++ b/rules/system_settings/system_settings_system_wide_preferences_configure.yaml
@@ -52,6 +52,11 @@ references:
       - 2.6.7 (level 1)
     controls v8:
       - 4.1
+  cmmc:
+    - AC.L1-3.1.1
+    - AC.L2-3.1.5
+    - AC.L2-3.1.6
+    - TBD - 3.14.3e
 macOS:
   - "13.0"
 tags:
@@ -64,6 +69,9 @@ tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
+  - cmmc_lvl1
 severity: "medium"
 mobileconfig: false
 mobileconfig_info:

--- a/rules/system_settings/system_settings_time_server_configure.yaml
+++ b/rules/system_settings/system_settings_time_server_configure.yaml
@@ -34,6 +34,8 @@ references:
       - 2.3.2.1 (level 1)
     controls v8:
       - 8.4
+  cmmc:
+    - AU.L2-3.3.7
 macOS:
   - "13.0"
 odv:
@@ -52,6 +54,8 @@ tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/system_settings/system_settings_time_server_enforce.yaml
+++ b/rules/system_settings/system_settings_time_server_enforce.yaml
@@ -34,6 +34,8 @@ references:
       - 2.3.2.1 (level 1)
     controls v8:
       - 8.4
+  cmmc:
+    - AU.L2-3.3.7
 macOS:
   - "13.0"
 tags:
@@ -47,6 +49,8 @@ tags:
   - cis_lvl1
   - cis_lvl2
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/system_settings/system_settings_token_removal_enforce.yaml
+++ b/rules/system_settings/system_settings_token_removal_enforce.yaml
@@ -33,6 +33,8 @@ references:
     - N/A
   800-171r2:
     - 3.1.10
+  cmmc:
+    - AC.L2-3.1.10
 macOS:
   - "13.0"
 tags:
@@ -42,6 +44,8 @@ tags:
   - 800-53r4_high 
   - 800-171 
   - cnssi-1253
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:

--- a/rules/system_settings/system_settings_touchid_unlock_disable.yaml
+++ b/rules/system_settings/system_settings_touchid_unlock_disable.yaml
@@ -30,6 +30,8 @@ references:
     - N/A
   800-171r2:
     - 3.1.10
+  cmmc:
+    - AC.L2-3.1.10
 macOS:
   - "13.0"
 tags:
@@ -39,6 +41,8 @@ tags:
   - 800-53r4_high
   - 800-171
   - cnssi-1253
+  - cmmc_lvl3
+  - cmmc_lvl2
 mobileconfig: true
 mobileconfig_info:
   com.apple.applicationaccess:

--- a/rules/system_settings/system_settings_wifi_disable.yaml
+++ b/rules/system_settings/system_settings_wifi_disable.yaml
@@ -42,6 +42,12 @@ references:
     controls v8:
       - 4.2
       - 12.6
+  cmmc:
+    - AC.L2-3.1.3
+    - AC.L2-3.1.16
+    - AC.L2-3.1.17
+    - TBD - 3.1.3e
+    - TBD - 3.14.3e
 macOS:
   - "13.0"
 tags:
@@ -54,6 +60,8 @@ tags:
   - 800-53r5_moderate 
   - 800-53r5_high
   - cisv8
+  - cmmc_lvl3
+  - cmmc_lvl2
 severity: "medium"
 mobileconfig: false
 mobileconfig_info:

--- a/rules/system_settings/system_settings_wifi_disable_when_connected_to_ethernet.yaml
+++ b/rules/system_settings/system_settings_wifi_disable_when_connected_to_ethernet.yaml
@@ -30,6 +30,11 @@ references:
   800-171r2:
     - 3.1.3
     - 3.1.17
+  cmmc:
+    - AC.L2-3.1.3
+    - AC.L2-3.1.17
+    - TBD - 3.1.3e
+    - TBD - 3.14.3e
 macOS:
   - "13.0"
 tags:
@@ -40,5 +45,7 @@ tags:
   - 800-171
   - cnssi-1253
   - permanent
+  - cmmc_lvl3
+  - cmmc_lvl2
 mobileconfig: false
 mobileconfig_info:

--- a/scripts/generate_baseline.py
+++ b/scripts/generate_baseline.py
@@ -520,7 +520,7 @@ def main():
         print("No rules found for the keyword provided, please verify from the following list:")
         available_tags(all_rules)
     else:
-        _established_benchmarks = ['stig', 'cis_lvl1', 'cis_lvl2']
+        _established_benchmarks = ['stig', 'cis_lvl1', 'cis_lvl2', 'cmmc_lvl1', 'cmmc_lvl2', 'cmmc_lvl3']
         if any(bm in args.keyword for bm in _established_benchmarks):
             benchmark = args.keyword
         else:

--- a/scripts/generate_guidance.py
+++ b/scripts/generate_guidance.py
@@ -20,7 +20,7 @@ from itertools import groupby
 from uuid import uuid4
 
 class MacSecurityRule():
-    def __init__(self, title, rule_id, severity, discussion, check, fix, cci, cce, nist_controls, nist_171, disa_stig, srg, cis, custom_refs, odv, tags, result_value, mobileconfig, mobileconfig_info, customized):
+    def __init__(self, title, rule_id, severity, discussion, check, fix, cci, cce, nist_controls, nist_171, disa_stig, srg, cis, cmmc, custom_refs, odv, tags, result_value, mobileconfig, mobileconfig_info, customized):
         self.rule_title = title
         self.rule_id = rule_id
         self.rule_severity = severity
@@ -34,6 +34,7 @@ class MacSecurityRule():
         self.rule_disa_stig = disa_stig
         self.rule_srg = srg
         self.rule_cis = cis
+        self.rule_cmmc = cmmc
         self.rule_custom_refs = custom_refs
         self.rule_odv = odv
         self.rule_result_value = result_value
@@ -56,6 +57,7 @@ class MacSecurityRule():
             rule_80053r5=self.rule_80053r5,
             rule_disa_stig=self.rule_disa_stig,
             rule_cis=self.rule_cis,
+            rule_cmmc=self.rule_cmmc,
             rule_srg=self.rule_srg,
             rule_result=self.rule_result_value
         )
@@ -1242,7 +1244,7 @@ def generate_xls(baseline_name, build_path, baseline_yaml):
     top = xlwt.easyxf("align: vert top")
     headers = xlwt.easyxf("font: bold on")
     counter = 1
-    column_counter = 16
+    column_counter = 17
     custom_ref_column = {}
     sheet1.write(0, 0, "CCE", headers)
     sheet1.write(0, 1, "Rule ID", headers)
@@ -1258,8 +1260,9 @@ def generate_xls(baseline_name, build_path, baseline_yaml):
     sheet1.write(0, 11, "DISA STIG", headers)
     sheet1.write(0, 12, "CIS Benchmark", headers)
     sheet1.write(0, 13, "CIS v8", headers)
-    sheet1.write(0, 14, "CCI", headers)
-    sheet1.write(0, 15, "Modifed Rule", headers)
+    sheet1.write(0, 14, "CMMC", headers)
+    sheet1.write(0, 15, "CCI", headers)
+    sheet1.write(0, 16, "Modifed Rule", headers)
     sheet1.set_panes_frozen(True)
     sheet1.set_horz_split_pos(1)
     sheet1.set_vert_split_pos(2)
@@ -1347,18 +1350,24 @@ def generate_xls(baseline_name, build_path, baseline_yaml):
                     cis = cis.replace(", ", "\n")
                     sheet1.write(counter, 13, cis, topWrap)
                     sheet1.col(13).width = 500 * 15
+        
+        cmmc_refs = (str(rule.rule_cmmc)).strip('[]\'')
+        cmmc_refs = cmmc_refs.replace(", ", "\n").replace("\'", "")
+
+        sheet1.write(counter, 14, cmmc_refs, topWrap)
+        sheet1.col(14).width = 500 * 15
 
         cci = (str(rule.rule_cci)).strip('[]\'')
         cci = cci.replace(", ", "\n").replace("\'", "")
 
-        sheet1.write(counter, 14, cci, topWrap)
-        sheet1.col(13).width = 400 * 15
+        sheet1.write(counter, 15, cci, topWrap)
+        sheet1.col(15).width = 400 * 15
 
         customized = (str(rule.rule_customized)).strip('[]\'')
         customized = customized.replace(", ", "\n").replace("\'", "")
 
-        sheet1.write(counter, 15, customized, topWrap)
-        sheet1.col(14).width = 400 * 15
+        sheet1.write(counter, 16, customized, topWrap)
+        sheet1.col(16).width = 400 * 15
 
         if rule.rule_custom_refs != ['None']:
             for title, ref in rule.rule_custom_refs.items():
@@ -1404,6 +1413,7 @@ def create_rules(baseline_yaml):
                   '800-53r5',
                   '800-171r2',
                   'cis',
+                  'cmmc',
                   'srg',
                   'custom']
 
@@ -1447,6 +1457,7 @@ def create_rules(baseline_yaml):
                                         rule_yaml['references']['disa_stig'],
                                         rule_yaml['references']['srg'],
                                         rule_yaml['references']['cis'],
+                                        rule_yaml['references']['cmmc'],
                                         rule_yaml['references']['custom'],
                                         rule_yaml['odv'],
                                         rule_yaml['tags'],
@@ -1558,6 +1569,7 @@ def parse_cis_references(reference):
             string += "!" + str(item) + "!* " + str(reference[item]) + "\n"
     return string
 
+# Might have to do something similar to above for cmmc
 
 def main():
 
@@ -1700,6 +1712,11 @@ def main():
     else:
         adoc_cis_show=":show_cis!:"
 
+    if "CMMC" in baseline_yaml['title'].upper():
+        adoc_cmmc_show=":show_CMMC:"
+    else:
+        adoc_cmmc_show=":show_CMMC!:"
+
     if "800" in baseline_yaml['title']:
          adoc_171_show=":show_171:"
     else:
@@ -1709,6 +1726,7 @@ def main():
         adoc_tag_show=":show_tags:"
         adoc_STIG_show=":show_STIG:"
         adoc_cis_show=":show_cis:"
+        adoc_cmmc_show=":show_CMMC:"
         adoc_171_show=":show_171:"
     else:
         adoc_tag_show=":show_tags!:"
@@ -1735,6 +1753,7 @@ def main():
         nist171_attribute=adoc_171_show,
         stig_attribute=adoc_STIG_show,
         cis_attribute=adoc_cis_show,
+        cmmc_attribute=adoc_cmmc_show,
         version=version_yaml['version'],
         os_version=version_yaml['os'],
         release_date=version_yaml['date']
@@ -1854,6 +1873,13 @@ def main():
                 cis = parse_cis_references(rule_yaml['references']['cis'])
 
             try:
+                rule_yaml['references']['cmmc']
+            except KeyError:
+                cmmc = ""
+            else:
+                cmmc = ulify(rule_yaml['references']['cmmc'])
+
+            try:
                 rule_yaml['references']['srg']
             except KeyError:
                 srg = '- N/A'
@@ -1937,6 +1963,7 @@ def main():
                     rule_800171=nist_800171,
                     rule_disa_stig=disa_stig,
                     rule_cis=cis,
+                    rule_cmmc=cmmc,
                     rule_cce=cce,
                     rule_custom_refs=custom_refs,
                     rule_tags=tags,
@@ -1954,6 +1981,7 @@ def main():
                     rule_800171=nist_800171,
                     rule_disa_stig=disa_stig,
                     rule_cis=cis,
+                    rule_cmmc=cmmc,
                     rule_cce=cce,
                     rule_tags=tags,
                     rule_srg=srg
@@ -1970,6 +1998,7 @@ def main():
                     rule_800171=nist_800171,
                     rule_disa_stig=disa_stig,
                     rule_cis=cis,
+                    rule_cmmc=cmmc,
                     rule_cce=cce,
                     rule_tags=tags,
                     rule_srg=srg,

--- a/templates/adoc_header.adoc
+++ b/templates/adoc_header.adoc
@@ -20,6 +20,7 @@ endif::[]
 $nist171_attribute
 $stig_attribute
 $cis_attribute
+$cmmc_attribute
 :version: $version ($release_date)
 :os: $os_version
 :proj-title: $html_header_title

--- a/templates/adoc_rule.adoc
+++ b/templates/adoc_rule.adoc
@@ -49,6 +49,11 @@ ifdef::show_CIS[]
 $rule_cis
 endif::[]
 
+ifdef::show_CMMC[]
+!CMMC
+!$rule_cmmc
+endif::[]
+
 !CCE
 !$rule_cce
 

--- a/templates/adoc_rule_no_setting.adoc
+++ b/templates/adoc_rule_no_setting.adoc
@@ -35,6 +35,10 @@ ifdef::show_CIS[]
 $rule_cis
 endif::[]
 
+ifdef::show_CMMC[]
+$rule_cmmc
+endif::[]
+
 ifdef::show_tags[]
 !CCE
 !$rule_cce


### PR DESCRIPTION
Re-adjusted CMMC baselines for Ventura. Included in this push:

- Baseline files for cmmc_lvl1, lvl2, lvl3
- Updated rules with cmmc tags
- Updated Template adoc files
- Updated mscp-data.yaml
- Updated baseline generation script
- Updated guidance generation script

Built from the /ventura branch. 