### PR TITLE
Adding missing inherent rule for LVL 3.

### DIFF
--- a/baselines/cmmc_lvl3.yaml
+++ b/baselines/cmmc_lvl3.yaml
@@ -196,6 +196,7 @@ profile:
     rules:
       - audit_record_reduction_report_generation
       - os_implement_cryptography
+      - os_isolate_security_functions
       - os_logical_access
       - os_malicious_code_prevention
       - os_obscure_password

--- a/rules/os/os_isolate_security_functions.yaml
+++ b/rules/os/os_isolate_security_functions.yaml
@@ -21,11 +21,14 @@ references:
     - N/A
   srg:
     - N/A
+  cmmc:
+    - TBD - 3.14.3e
 macOS:
   - "13.0"
 tags:
   - 800-53r5_high
   - 800-53r4_high
+  - cmmc_lvl3
   - inherent
 mobileconfig: false
 mobileconfig_info:


### PR DESCRIPTION
Missed the only level 3 only rule. 

Add to cmmc_lvl3:
os_isolate_security_functions 