### PR TITLE
Change title for "Ensure Auto Update is Enabled" to "Ensure Automatically Check for Updates is Enabled" for system_settings_software_update_enforce

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -2,7 +2,7 @@
 
 This document provides a high-level view of the changes to the macOS Security Compliance Project.
 
-== [Ventura, Revision 1.1] - 2022-12-06
+== [Ventura, Revision 1.1] - 2022-12-08
 
 * Rules
 ** Added Rules

--- a/baselines/cis_lvl1.yaml
+++ b/baselines/cis_lvl1.yaml
@@ -96,6 +96,7 @@ profile:
       - system_settings_softwareupdate_current
       - system_settings_ssh_disable
       - system_settings_system_wide_preferences_configure
+      - system_settings_time_machine_encrypted_configure
       - system_settings_time_server_configure
       - system_settings_time_server_enforce
       - system_settings_wake_network_access_disable

--- a/rules/system_settings/system_settings_time_machine_encrypted_configure.yaml
+++ b/rules/system_settings/system_settings_time_machine_encrypted_configure.yaml
@@ -37,7 +37,7 @@ references:
     - N/A
   cis:
     benchmark: 
-      - 2.3.4.2 (level 2)
+      - 2.3.4.2 (level 1)
     controls v8:
       - 3.6
       - 3.11
@@ -45,6 +45,7 @@ references:
 macOS:
   - "13.0"
 tags:
+  - cis_lvl1
   - cis_lvl2
   - cisv8
 mobileconfig: false

--- a/templates/adoc_additional_docs.adoc
+++ b/templates/adoc_additional_docs.adoc
@@ -56,5 +56,5 @@ ASSOCIATED DOCUMENTS
 |===
 |Document Number or Descriptor
 |Document Title
-|link:https://www.cisecurity.org/benchmark/apple_os/[Apple macOS 12.0]|_CIS Apple macOS 12.0 Benchmark version 2.1.0_
+|link:https://www.cisecurity.org/benchmark/apple_os/[Apple macOS 13.0]|_CIS Apple macOS 13.0 Benchmark version 1.0.0_
 |===


### PR DESCRIPTION
The title Ensure Auto Update is Enabled is confusing because this rule uses the AutomaticCheckEnabled key, which when set to true enables Automatically Check for Updates. This rule will not automatically download or automatically install updates. The existing title of Ensure Auto Update is Enabled might give a lay person the incorrect impression that if enabled by itself, this rule will automatically check, download, and install macOS updates. 

Please consider renaming the title to something more descriptive, such as Ensure Automatically Check for Updates is Enabled." I will submit a ticket for the CIS benchmark as well. Thank you!