### PR TITLE
Updating Monterey CIS safari checks

### DIFF
--- a/baselines/cis_lvl2.yaml
+++ b/baselines/cis_lvl2.yaml
@@ -56,8 +56,11 @@ profile:
       - os_password_hint_remove
       - os_policy_banner_loginwindow_enforce
       - os_root_disable
+      - os_safari_advertising_privacy_protection_enable
       - os_safari_open_safe_downloads_disable
-      - os_show_filename_extensions_enable
+      - os_safari_prevent_cross-site_tracking_enable
+      - os_safari_show_full_website_address_enable
+      - os_safari_warn_fraudulent_website_enable
       - os_sip_enable
       - os_software_update_deferral
       - os_sudo_timeout_configure

--- a/rules/os/os_safari_advertising_privacy_protection_enable.yaml
+++ b/rules/os/os_safari_advertising_privacy_protection_enable.yaml
@@ -1,0 +1,38 @@
+id: os_safari_advertising_privacy_protection_enable
+title: "Ensure Advertising Privacy Protection in Safari Is Enabled"
+discussion: |
+  Allow privacy-preserving measurement of ad effectiveness _MUST_ be enabled in Safari. 
+check: |
+  /usr/bin/profiles -P -o stdout | /usr/bin/grep -c '"WebKitPreferences.privateClickMeasurementEnabled" = 1' | /usr/bin/awk '{ if ($1 >= 1) {print "1"} else {print "0"}}'
+result:
+  integer: 1
+fix: |
+  This is implemented by a Configuration Profile.
+references:
+  cce:
+    - CCE-92002-5
+  cci:
+    - N/A
+  800-53r5:
+    - N/A
+  800-53r4:
+    - N/A
+  disa_stig:
+    - N/A
+  srg:
+    - N/A
+  cis:
+    benchmark:
+      - 7.2.7 (level 1)
+    controls v8:
+      - 9.1
+macOS:
+  - "12.0"
+tags:
+  - cis_lvl1
+  - cis_lvl2
+  - cisv8
+mobileconfig: true
+mobileconfig_info:
+  com.apple.Safari:
+    WebKitPreferences.privateClickMeasurementEnabled: true

--- a/rules/os/os_safari_advertising_privacy_protection_enable.yaml
+++ b/rules/os/os_safari_advertising_privacy_protection_enable.yaml
@@ -10,7 +10,7 @@ fix: |
   This is implemented by a Configuration Profile.
 references:
   cce:
-    - CCE-92002-5
+    - N/A
   cci:
     - N/A
   800-53r5:

--- a/rules/os/os_safari_open_safe_downloads_disable.yaml
+++ b/rules/os/os_safari_open_safe_downloads_disable.yaml
@@ -23,7 +23,7 @@ references:
     - N/A
   cis:
     benchmark:
-      - 6.3 (level 1)
+      - 7.2.1 (level 1)
     controls v8:
       - 9
 macOS:

--- a/rules/os/os_safari_prevent_cross-site_tracking_enable.yaml
+++ b/rules/os/os_safari_prevent_cross-site_tracking_enable.yaml
@@ -1,0 +1,41 @@
+id: os_safari_prevent_cross-site_tracking_enable
+title: "Ensure Prevent Cross-site Tracking in Safari Is Enabled"
+discussion: |
+  Prevent cross-site tracking _MUST_ be enabled in Safari.
+check: |
+  /usr/bin/profiles -P -o stdout | /usr/bin/grep -cE '"WebKitPreferences.storageBlockingPolicy" = 1|"WebKitStorageBlockingPolicy" = 1|"BlockStoragePolicy" =2' | /usr/bin/awk '{ if ($1 >= 1) {print "1"} else {print "0"}}'
+result:
+  integer: 1
+fix: |
+  This is implemented by a Configuration Profile.
+references:
+  cce:
+    - CCE-92003-3
+  cci:
+    - N/A
+  800-53r5:
+    - N/A
+  800-53r4:
+    - N/A
+  disa_stig:
+    - N/A
+  srg:
+    - N/A
+  cis:
+    benchmark:
+      - 7.2.5 (level 1)
+    controls v8:
+      - 9.1
+      - 9.3
+macOS:
+  - "12.0"
+tags:
+  - cis_lvl1
+  - cis_lvl2
+  - cisv8
+mobileconfig: true
+mobileconfig_info:
+  com.apple.Safari:
+    WebKitPreferences.storageBlockingPolicy: 1
+    WebKitStorageBlockingPolicy: 1
+    BlockStoragePolicy: 2

--- a/rules/os/os_safari_prevent_cross-site_tracking_enable.yaml
+++ b/rules/os/os_safari_prevent_cross-site_tracking_enable.yaml
@@ -10,7 +10,7 @@ fix: |
   This is implemented by a Configuration Profile.
 references:
   cce:
-    - CCE-92003-3
+    - N/A
   cci:
     - N/A
   800-53r5:

--- a/rules/os/os_safari_show_full_website_address_enable.yaml
+++ b/rules/os/os_safari_show_full_website_address_enable.yaml
@@ -10,7 +10,7 @@ fix: |
   This is implemented by a Configuration Profile.
 references:
   cce:
-    - CCE-92004-1
+    - N/A
   cci:
     - N/A
   800-53r5:

--- a/rules/os/os_safari_show_full_website_address_enable.yaml
+++ b/rules/os/os_safari_show_full_website_address_enable.yaml
@@ -1,0 +1,38 @@
+id: os_safari_show_full_website_address_enable
+title: "Ensure Show Full Website Address in Safari Is Enabled"
+discussion: |
+  Show full website address _MUST_ be enabled in Safari. 
+check: |
+  /usr/bin/profiles -P -o stdout | /usr/bin/grep -c 'ShowFullURLInSmartSearchField = 1' | /usr/bin/awk '{ if ($1 >= 1) {print "1"} else {print "0"}}'
+result:
+  integer: 1
+fix: |
+  This is implemented by a Configuration Profile.
+references:
+  cce:
+    - CCE-92004-1
+  cci:
+    - N/A
+  800-53r5:
+    - N/A
+  800-53r4:
+    - N/A
+  disa_stig:
+    - N/A
+  srg:
+    - N/A
+  cis:
+    benchmark:
+      - 7.2.8 (level 1)
+    controls v8:
+      - 9.1
+macOS:
+  - "12.0"
+tags:
+  - cis_lvl1
+  - cis_lvl2
+  - cisv8
+mobileconfig: true
+mobileconfig_info:
+  com.apple.Safari:
+    ShowFullURLInSmartSearchField: true

--- a/rules/os/os_safari_warn_fraudulent_website_enable.yaml
+++ b/rules/os/os_safari_warn_fraudulent_website_enable.yaml
@@ -10,7 +10,7 @@ fix: |
   This is implemented by a Configuration Profile.
 references:
   cce:
-    - CCE-92005-8
+    - N/A
   cci:
     - N/A
   800-53r5:

--- a/rules/os/os_safari_warn_fraudulent_website_enable.yaml
+++ b/rules/os/os_safari_warn_fraudulent_website_enable.yaml
@@ -1,0 +1,39 @@
+id: os_safari_warn_fraudulent_website_enable
+title: "Ensure Warn When Visiting A Fradulent Website in Safari Is Enabled"
+discussion: |
+  Warn when visiting a fraudulent website _MUST_ be enabled in Safari. 
+check: |
+  /usr/bin/profiles -P -o stdout | /usr/bin/grep -c 'WarnAboutFraudulentWebsites = 1' | /usr/bin/awk '{ if ($1 >= 1) {print "1"} else {print "0"}}'
+result:
+  integer: 1
+fix: |
+  This is implemented by a Configuration Profile.
+references:
+  cce:
+    - CCE-92005-8
+  cci:
+    - N/A
+  800-53r5:
+    - N/A
+  800-53r4:
+    - N/A
+  disa_stig:
+    - N/A
+  srg:
+    - N/A
+  cis:
+    benchmark:
+      - 7.2.4 (level 1)
+    controls v8:
+      - 9.1
+      - 9.3
+macOS:
+  - "12.0"
+tags:
+  - cis_lvl1
+  - cis_lvl2
+  - cisv8
+mobileconfig: true
+mobileconfig_info:
+  com.apple.Safari:
+    WarnAboutFraudulentWebsites: true


### PR DESCRIPTION
The CIS baselines have updated Safari checks for Monterey that were missing from the project. I have updated the baselines and included the rules. I have also updated the reference number for `os_safari_open_safe_downloads_disable.yaml`