### PR TITLE
patch sshd checks for issue #245

### DIFF
--- a/rules/os/os_sshd_client_alive_count_max_configure.yaml
+++ b/rules/os/os_sshd_client_alive_count_max_configure.yaml
@@ -5,7 +5,7 @@ discussion: |
 
   NOTE: /etc/ssh/sshd_config will be automatically modified to its original state following any update or major upgrade to the operating system.
 check: |
-  /usr/sbin/sshd -T | /usr/bin/awk '/clientalivecountmax/{print $2}'
+  [ -z "$(find /etc/ssh/ -name ssh_host\*key)" ] && echo "$ODV" || { /usr/sbin/sshd -T | /usr/bin/awk '/clientalivecountmax/{print $2}' ;}
 result:
   integer: $ODV
 fix: |

--- a/rules/os/os_sshd_client_alive_interval_configure.yaml
+++ b/rules/os/os_sshd_client_alive_interval_configure.yaml
@@ -7,7 +7,7 @@ discussion: |
 
   NOTE: /etc/ssh/sshd_config will be automatically modified to its original state following any update or major upgrade to the operating system.
 check: |
-  /usr/sbin/sshd -T | /usr/bin/awk '/clientaliveinterval/{print $2}'
+  [ -z "$(find /etc/ssh/ -name ssh_host\*key)" ] && echo "$ODV" || { /usr/sbin/sshd -T | /usr/bin/awk '/clientalivecountmax/{print $2}' ;}
 result:
   integer: $ODV
 fix: |

--- a/rules/os/os_sshd_client_alive_interval_configure.yaml
+++ b/rules/os/os_sshd_client_alive_interval_configure.yaml
@@ -7,7 +7,7 @@ discussion: |
 
   NOTE: /etc/ssh/sshd_config will be automatically modified to its original state following any update or major upgrade to the operating system.
 check: |
-  [ -z "$(find /etc/ssh/ -name ssh_host\*key)" ] && echo "$ODV" || { /usr/sbin/sshd -T | /usr/bin/awk '/clientalivecountmax/{print $2}' ;}
+  [ -z "$(find /etc/ssh/ -name ssh_host\*key)" ] && echo "$ODV" || { /usr/sbin/sshd -T | /usr/bin/awk '/clientaliveinterval/{print $2}' ;}
 result:
   integer: $ODV
 fix: |

--- a/rules/os/os_sshd_fips_140_ciphers.yaml
+++ b/rules/os/os_sshd_fips_140_ciphers.yaml
@@ -9,7 +9,7 @@ discussion: |
 
   NOTE: /etc/ssh/sshd_config will be automatically modified to its original state following any update or major upgrade to the operating system.
 check: |
-  /usr/sbin/sshd -T | /usr/bin/grep -ci "^Ciphers aes256-ctr,aes192-ctr,aes128-ctr"
+  [ -z "$(find /etc/ssh/ -name ssh_host\*key)" ] && echo "1" || { /usr/sbin/sshd -T | /usr/bin/grep -ci "^Ciphers aes256-ctr,aes192-ctr,aes128-ctr" ;}
 result:
   integer: 1
 fix: |

--- a/rules/os/os_sshd_fips_140_macs.yaml
+++ b/rules/os/os_sshd_fips_140_macs.yaml
@@ -9,7 +9,7 @@ discussion: |
 
   NOTE: /etc/ssh/sshd_config will be automatically modified to its original state following any update or major upgrade to the operating system.
 check: |
-  /usr/sbin/sshd -T | /usr/bin/grep -ci "^MACs hmac-sha2-256,hmac-sha2-512"
+  [ -z "$(find /etc/ssh/ -name ssh_host\*key)" ] && echo "1" || { /usr/sbin/sshd -T | /usr/bin/grep -ci "^MACs hmac-sha2-256,hmac-sha2-512" ;}
 result:
   integer: 1
 fix: |

--- a/rules/os/os_sshd_fips_compliant.yaml
+++ b/rules/os/os_sshd_fips_compliant.yaml
@@ -11,10 +11,10 @@ discussion: |
 check: |
   fips_sshd_config=("Ciphers aes128-gcm@openssh.com" "HostbasedAcceptedAlgorithms ecdsa-sha2-nistp256,ecdsa-sha2-nistp256-cert-v01@openssh.com" "HostKeyAlgorithms ecdsa-sha2-nistp256,ecdsa-sha2-nistp256-cert-v01@openssh.com" "KexAlgorithms ecdh-sha2-nistp256" "MACs hmac-sha2-256" "PubkeyAcceptedAlgorithms ecdsa-sha2-nistp256,ecdsa-sha2-nistp256-cert-v01@openssh.com" "CASignatureAlgorithms ecdsa-sha2-nistp256")
   total=0
-  for config in $fips_sshd_config; do
-    total=$(expr $(/usr/sbin/sshd -T | /usr/bin/grep -i -c "$config") + $total)
-  done
-
+  [ -z "$(find /etc/ssh/ -name ssh_host\*key)" ] && total=7 \
+    || { for config in $fips_sshd_config; do
+          total=$(expr $(/usr/sbin/sshd -T | /usr/bin/grep -ci "$config") + $total)
+        done ;}
   echo $total
 result:
   integer: 7

--- a/rules/os/os_sshd_key_exchange_algorithm_configure.yaml
+++ b/rules/os/os_sshd_key_exchange_algorithm_configure.yaml
@@ -11,7 +11,7 @@ discussion: |
 
   NOTE: /etc/ssh/sshd_config will be automatically modified to its original state following any update or major upgrade to the operating system.
 check: |
-  /usr/sbin/sshd -T | /usr/bin/grep -ci "^KexAlgorithms diffie-hellman-group-exchange-sha256"
+  [ -z "$(find /etc/ssh/ -name ssh_host\*key)" ] && echo "1" || { /usr/sbin/sshd -T | /usr/bin/grep -ci "^KexAlgorithms diffie-hellman-group-exchange-sha256" ;}
 result:
   integer: 1
 fix: |

--- a/rules/os/os_sshd_login_grace_time_configure.yaml
+++ b/rules/os/os_sshd_login_grace_time_configure.yaml
@@ -5,7 +5,7 @@ discussion: |
 
   NOTE: /etc/ssh/sshd_config will be automatically modified to its original state following any update or major upgrade to the operating system.
 check: |
-  /usr/sbin/sshd -T | /usr/bin/awk '/logingracetime/{print $2}'
+  [ -z "$(find /etc/ssh/ -name ssh_host\*key)" ] && echo "$ODV" || { /usr/sbin/sshd -T | /usr/bin/awk '/logingracetime/{print $2}' ;}
 result:
   integer: $ODV
 fix: |

--- a/rules/os/os_sshd_permit_root_login_configure.yaml
+++ b/rules/os/os_sshd_permit_root_login_configure.yaml
@@ -7,7 +7,7 @@ discussion: |
   
   NOTE: /etc/ssh/sshd_config will be automatically modified to its original state following any update or major upgrade to the operating system.
 check: |
-  /usr/sbin/sshd -T | /usr/bin/awk '/permitrootlogin/{print $2}'
+  [ -z "$(find /etc/ssh/ -name ssh_host\*key)" ] && echo "no" || { /usr/sbin/sshd -T | /usr/bin/awk '/permitrootlogin/{print $2}' ;}
 result:
   string: "no"
 fix: |


### PR DESCRIPTION
This PR adds a test for host keys before checking the sshd config. If there are no host keys, the check returns a successful result because sshd won't run and the test doesn't apply. #245 