### PR TITLE
Security Certifications and Compliance Center link updated

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -27,7 +27,7 @@ The macOS Security Compliance Project is an link:LICENSE.md[open source] effort 
 
 This project is the technical implementation of NIST Special Publication, 800-219 https://csrc.nist.gov/publications/detail/sp/800-219/final[Automated Secure Configuration Guidance from the macOS Security Compliance Project (mSCP)].  NIST Special Publication 800-219 is the official guidance from for automated secure configuration for macOS.
 
-Apple acknowledges the macOS Security Compliance Project with information on their https://support.apple.com/guide/sccc/macos-security-compliance-project-sccc22685bb2/web[Security Certifications and Compliance Center] page.
+Apple acknowledges the macOS Security Compliance Project with information on their https://support.apple.com/guide/certifications/apc322685bb2/1/web/1.0[Security Certifications and Compliance Center] page.
 
 This project can be used as a resource to easily create customized security baselines of technical security controls by leveraging a library of atomic actions which are mapped to the compliance requirements defined in NIST SP 800-53 (Rev. 5). It can also be used to develop customized guidance to meet the particular cybersecurity needs of any organization.  
 


### PR DESCRIPTION
old: https://support.apple.com/guide/sccc/macos-security-compliance-project-sccc22685bb2/web

new:
https://support.apple.com/guide/certifications/apc322685bb2/1/web/1.0