### PR TITLE
change removal of public ssh key file

### DIFF
--- a/scripts/generate_guidance.py
+++ b/scripts/generate_guidance.py
@@ -1082,7 +1082,7 @@ fi
 
 if [[ "$ssh_key_check" -ne 0 ]]; then
     /bin/rm /etc/ssh/ssh_host_rsa_key
-    /bin/rm /etc/ssh/ssh_host_rsa_key.public
+    /bin/rm /etc/ssh/ssh_host_rsa_key.pub
     ssh_key_check=0
 fi
     """


### PR DESCRIPTION
The file created was a .pub file so the removal should be .pub and not .public

I kept getting errors when running my generated audit script from Jamf. The script is trying to remove a file by doing `/bin/rm /etc/ssh/ssh_host_rsa_key.public` but i get a "No such file or directory".
When I run the command that is creating the ssh_host_rsa_key by doing `/usr/bin/ssh-keygen -q -N "" -t rsa -b 4096 -f /etc/ssh/ssh_host_rsa_key` the result is 2 files: `/etc/ssh/ssh_host_rsa_key` and `/etc/ssh/ssh_host_rsa_key.pub`
The created file is a **.pub** in stead of **.public**.
When I change the `/bin/rm /etc/ssh/ssh_host_rsa_key.public` into `/bin/rm /etc/ssh/ssh_host_rsa_key.pub` the file gets deleted.
<img width="752" alt="Screenshot 2023-08-03 at 14 45 02" src="https://github.com/usnistgov/macos_security/assets/54109523/bfc4d59e-642f-44e2-80c7-dfc8b337fd86">
