### PR TITLE
Fix typos

### DIFF
--- a/rules/os/os_application_sandboxing.yaml
+++ b/rules/os/os_application_sandboxing.yaml
@@ -1,5 +1,5 @@
 id: os_application_sandboxing
-title: "Ensure Seperate Execution Domain for Processes"
+title: "Ensure Separate Execution Domain for Processes"
 discussion: |
   The inherent configuration of the macOS _IS_ in compliance as Apple has implemented multiple features Mandatory access controls (MAC), System Integrity Protection (SIP), and application sandboxing.
 

--- a/rules/os/os_hibernate_mode_apple_silicon_enable.yaml
+++ b/rules/os/os_hibernate_mode_apple_silicon_enable.yaml
@@ -6,7 +6,7 @@ discussion: |
   This will store a copy of memory to persistent storage, and will remove power to memory. This setting will stop the potential for a cold-boot attack.
 
   Apple Silicon MacBooks should set sleep timeout to 10 minutes (600 seconds) or less and the display sleep timeout should be 15 minutes (900 seconds) or less but greater than the sleep setting.
-  This setting ensures that MacBooks will not hibernate and require FileVault authentication wheneve the display goes to sleep for a short period of time.
+  This setting ensures that MacBooks will not hibernate and require FileVault authentication whenever the display goes to sleep for a short period of time.
 
   NOTE: Hibernate mode will disable instant wake on Apple Silicon laptops.
 check: |

--- a/rules/os/os_required_crypto_module.yaml
+++ b/rules/os/os_required_crypto_module.yaml
@@ -5,7 +5,7 @@ discussion: |
 
   macOS contains many open source projects that may use their own cryptographic libraries typically for the purposes of maintaining platform independence. These services are not covered by the Apple FIPS Validation of the CoreCrypto and CoreCrypto Kernel modules.
 
-  Apple is committed to the FIPS validation process and historically has always submitted and validated the cryptographic modules in macOS. macOS Ventura will be submitted for FIPS validation.
+  Apple is committed to the FIPS validation process and historically has always submitted and validated the cryptographic modules in macOS. macOS Sonoma will be submitted for FIPS validation.
 
   link:https://csrc.nist.gov/Projects/cryptographic-module-validation-program/validated-modules[]
 

--- a/rules/os/os_screensaver_loginwindow_enforce.yaml
+++ b/rules/os/os_screensaver_loginwindow_enforce.yaml
@@ -8,7 +8,7 @@ check: |
   .objectForKey('moduleName').js
   EOS
 result:
-  string: "Ventura"
+  string: "Sonoma"
 fix: |
   This is implemented by a Configuration Profile.
 references:
@@ -44,4 +44,4 @@ severity: "medium"
 mobileconfig: true
 mobileconfig_info:
   com.apple.screensaver:
-    moduleName: "Ventura"
+    moduleName: "Sonoma"

--- a/rules/os/os_sudoers_timestamp_type_configure.yaml
+++ b/rules/os/os_sudoers_timestamp_type_configure.yaml
@@ -1,7 +1,7 @@
 id: os_sudoers_timestamp_type_configure
 title: "Configure Sudoers Timestamp Type"
 discussion: |
-  The file /etc/sudoers _MUST_ be configured to not include a timestamp_type of global or ppid aand be configured for timestamp record types of tty.
+  The file /etc/sudoers _MUST_ be configured to not include a timestamp_type of global or ppid and be configured for timestamp record types of tty.
 
   This rule ensures that the "sudo" command will prompt for the administrator's password at least once in each newly opened terminal window. This prevents a malicious user from taking advantage of an unlocked computer or an abandoned logon session by bypassing the normal password prompt requirement.
 check: |


### PR DESCRIPTION
aand → and
seperate → separate
wheneve → whenever

All mentions of Ventura were replaced with Sonoma.