### PR TITLE
Update timeServer recommendation 

### DIFF
--- a/rules/system_settings/system_settings_time_server_configure.yaml
+++ b/rules/system_settings/system_settings_time_server_configure.yaml
@@ -1,7 +1,7 @@
 id: system_settings_time_server_configure
 title: "Configure macOS to Use an Authorized Time Server"
 discussion: |
-  Approved time servers _MUST_ be the only servers configured for use.
+  Approved time server _MUST_ be the only server configured for use. As of macOS 10.13 only one time server is supported.
 
   This rule ensures the uniformity of time stamps for information systems with multiple system clocks and systems connected over a network.
 check: |
@@ -41,7 +41,7 @@ references:
 macOS:
   - "14.0"
 odv:
-  hint: "Name of timeserver(s) separated by commas."
+  hint: "Name of timeserver. As of macOS 10.13 only one time server is supported."
   recommended: "time-a.nist.gov,time-b.nist.gov"
   cis_lvl1: "time.apple.com"
   cis_lvl2: "time.apple.com"


### PR DESCRIPTION
As of macOS 10.13 only one time server is supported.

See Apple Update from 13/12/2023 here: https://github.com/apple/device-management/blob/release/mdm/profiles/com.apple.MCX(TimeServer).yaml#L21-L25