### PR TITLE
Changed block in all to block drop in all at line 94

### DIFF
--- a/includes/enablePF-mscp.sh
+++ b/includes/enablePF-mscp.sh
@@ -91,7 +91,7 @@ cat > /etc/pf.anchors/mscp_pf_anchors <<'ENDCONFIG'
 anchor mscp_pf_anchors
 
 #default deny all in, allow all out and keep state
-block in all
+block drop in all
 pass out all keep state
 
 #pass in all packets from localhost


### PR DESCRIPTION
This will set the pf to drop inbound packets by default rather than replying with a reject. Changing this to drop also allows the compliance check "os_firewall_default_deny_require" to pass after running this script. since that is checking if the rule "block drop in all" exists in the pf.