### PR TITLE
Update pwpolicy_custom_regex_enforce.yaml

### DIFF
--- a/rules/pwpolicy/pwpolicy_custom_regex_enforce.yaml
+++ b/rules/pwpolicy/pwpolicy_custom_regex_enforce.yaml
@@ -50,9 +50,9 @@ macOS:
   - '14.0'
 odv:
   hint: Custom regex (recommended is 1 upper and 1 lowercase)
-  recommended: .*[A-Z]{1,}.*[a-z]{1,}.*
-  cis_lvl2: .*[A-Z]{1,}.*[a-z]{1,}.*
-  stig: .*[A-Z]{1,}.*[a-z]{1,}.*
+  recommended: ^(?=.*[A-Z])(?=.*[a-z]).*$
+  cis_lvl2: ^(?=.*[A-Z])(?=.*[a-z]).*$
+  stig: ^(?=.*[A-Z])(?=.*[a-z]).*$
 tags:
   - 800-171
   - 800-53r4_low


### PR DESCRIPTION
The new regex from my previous PR (#363) actually still required the lowercase letter to follow the capital letter in the password even if they were no longer required to be right next to each other. This new regex does not require the capital or lowercase letter to be in any particular order but will require that at least one capital and one lowercase is in the password. This is accomplished using a positive lookahead.