### PR TITLE
iOS 17 - updated STIG ID rules, tags, and ODVs

### DIFF
--- a/rules/icloud/icloud_backup_disabled.yaml
+++ b/rules/icloud/icloud_backup_disabled.yaml
@@ -20,7 +20,7 @@ references:
   sfr:
     - 'FMT_MOF_EXT.1.2 #40'
   disa_stig:
-    -AIOS-17-003000
+    - AIOS-17-003000
   800-171r2:
     - N/A
   cis:

--- a/rules/icloud/icloud_backup_disabled.yaml
+++ b/rules/icloud/icloud_backup_disabled.yaml
@@ -20,7 +20,7 @@ references:
   sfr:
     - 'FMT_MOF_EXT.1.2 #40'
   disa_stig:
-    - N/A
+    -AIOS-17-003000
   800-171r2:
     - N/A
   cis:
@@ -38,6 +38,7 @@ tags:
   - cis_lvl1_enterprise
   - cis_lvl2_enterprise
   - cisv8
+  - ios_stig
 severity: "medium"
 supervised: false
 mobileconfig: true

--- a/rules/icloud/icloud_keychain_disable.yaml
+++ b/rules/icloud/icloud_keychain_disable.yaml
@@ -22,7 +22,7 @@ references:
   sfr:
     - 'FMT_MOF_EXT.1.2 #40'
   disa_stig:
-    - N/A
+    - AIOS-17-003300
   800-171r2:
     - N/A
   cis:
@@ -42,6 +42,7 @@ tags:
   - cis_lvl1_enterprise
   - cis_lvl2_enterprise
   - cisv8
+  - ios_stig
 supervised: false
 mobileconfig: true
 mobileconfig_info:

--- a/rules/icloud/icloud_managed_apps_store_data_disabled.yaml
+++ b/rules/icloud/icloud_managed_apps_store_data_disabled.yaml
@@ -43,8 +43,8 @@ tags:
   - cis_lvl1_enterprise
   - cis_lvl2_enterprise
   - cisv8
-  -ios_stig
-  -ios_stig_byoad
+  - ios_stig
+  - ios_stig_byoad
 supervised: false
 mobileconfig: true
 mobileconfig_info:

--- a/rules/icloud/icloud_managed_apps_store_data_disabled.yaml
+++ b/rules/icloud/icloud_managed_apps_store_data_disabled.yaml
@@ -21,7 +21,8 @@ references:
   sfr:
     - 'FMT_MOF_EXT.1.2 #40'
   disa_stig:
-    - N/A
+    - AIOS-17-003600
+    - AIOS-17-703600
   800-171r2:
     - N/A
   cis:
@@ -42,6 +43,8 @@ tags:
   - cis_lvl1_enterprise
   - cis_lvl2_enterprise
   - cisv8
+  -ios_stig
+  -ios_stig_byoad
 supervised: false
 mobileconfig: true
 mobileconfig_info:

--- a/rules/icloud/icloud_photos_disable.yaml
+++ b/rules/icloud/icloud_photos_disable.yaml
@@ -20,7 +20,7 @@ references:
   sfr:
     - 'FMT_SMF_EXT.1.1 #47'
   disa_stig:
-    - N/A
+    - AIOS-17-003450
   800-171r2:
     - N/A
   cis:
@@ -37,6 +37,7 @@ tags:
   - 800-53r5_low
   - 800-53r5_moderate
   - 800-53r5_high
+  - ios_stig
 severity: medium
 supervised: false
 mobileconfig: true

--- a/rules/icloud/icloud_shared_photo_stream_disable.yaml
+++ b/rules/icloud/icloud_shared_photo_stream_disable.yaml
@@ -20,7 +20,7 @@ references:
   sfr:
     - 'FMT_MOF_EXT.1.2 #40'
   disa_stig:
-    - N/A
+    - AIOS-17-003500
   800-171r2:
     - N/A
   cis:
@@ -35,6 +35,7 @@ tags:
   - 800-53r5_low
   - 800-53r5_moderate
   - 800-53r5_high
+  - ios_stig
 severity: "medium"
 supervised: false
 mobileconfig: true

--- a/rules/icloud/icloud_sync_disable.yaml
+++ b/rules/icloud/icloud_sync_disable.yaml
@@ -21,7 +21,7 @@ references:
   sfr:
     - 'FMT_MOF_EXT.1.2 #40'
   disa_stig:
-    - N/A
+    - AIOS-17-003200
   800-171r2:
     - N/A
   cis:
@@ -39,6 +39,7 @@ tags:
   - cis_lvl1_enterprise
   - cis_lvl2_enterprise
   - cisv8
+  - ios_stig
 severity: "medium"
 supervised: true
 mobileconfig: true

--- a/rules/os/os_airdrop_disable.yaml
+++ b/rules/os/os_airdrop_disable.yaml
@@ -24,7 +24,8 @@ references:
     - 'FMT_SMF_EXT.1.1/WLAN'
     - 'FMT_SMF_EXT.1.1 #47'
   disa_stig:
-    - N/A
+    - AIOS-17-010200
+    - AIOS-17-012500
   800-171r2:
     - N/A
   cis:
@@ -39,6 +40,7 @@ tags:
   - 800-53r5_low
   - 800-53r5_moderate
   - 800-53r5_high
+  - ios_stig
 severity: "medium"
 supervised: true
 mobileconfig: true

--- a/rules/os/os_airdrop_unmanaged_destination_enable.yaml
+++ b/rules/os/os_airdrop_unmanaged_destination_enable.yaml
@@ -21,7 +21,8 @@ references:
   sfr:
     - 'FMT_SMF_EXT.1.1 #47'
   disa_stig:
-    - N/A
+    - AIOS-17-011500
+    - AIOS-17-711500
   800-171r2:
     - N/A
   cis:
@@ -42,6 +43,8 @@ tags:
   - cis_lvl1_enterprise
   - cis_lvl2_enterprise
   - cisv8
+  - ios_stig
+  - ios_stig_byoad
 severity: "medium"
 supervised: false
 mobileconfig: true

--- a/rules/os/os_airplay_password_require.yaml
+++ b/rules/os/os_airplay_password_require.yaml
@@ -14,7 +14,8 @@ references:
   sfr:
     - 'FMT_SMF_EXT.1.1 #40'
   disa_stig:
-    - N/A
+    - AIOS-17-010900
+    - AIOS-17-710900
   800-171r2:
     - N/A
   cis:
@@ -28,6 +29,8 @@ tags:
   - ios
   - 800-53r5_moderate
   - 800-53r5_high
+  - ios_stig
+  - ios_stig_byoad
 severity: low
 supervised: false
 mobileconfig: true

--- a/rules/os/os_allow_contacts_read_managed_sources_unmanaged_destinations_disable.yaml
+++ b/rules/os/os_allow_contacts_read_managed_sources_unmanaged_destinations_disable.yaml
@@ -20,7 +20,8 @@ references:
     - 'FMT_SMF_EXT.1.1 #42'
     - 'FDP_ACF_EXT.1.2'
   disa_stig:
-    - N/A
+    - AIOS-17-012400
+    - AIOS-17-712400
   800-171r2:
     - N/A
   cis:
@@ -35,6 +36,8 @@ tags:
   - 800-53r5_low
   - 800-53r5_moderate
   - 800-53r5_high
+  - ios_stig
+  - ios_stig_byoad
 severity: low
 supervised: false
 mobileconfig: true

--- a/rules/os/os_allow_contacts_write_managed_sources_unmanaged_destinations_disable.yaml
+++ b/rules/os/os_allow_contacts_write_managed_sources_unmanaged_destinations_disable.yaml
@@ -20,7 +20,8 @@ references:
     - 'FMT_SMF_EXT.1.1 #42'
     - 'FDP_ACF_EXT.1.2'
   disa_stig:
-    - N/A
+    - AIOS-17-012300
+    - AIOS-17-712300
   800-171r2:
     - N/A
   cis:
@@ -35,6 +36,8 @@ tags:
   - 800-53r5_low
   - 800-53r5_moderate
   - 800-53r5_high
+  - ios_stig
+  - ios_stig_byoad
 severity: "low"
 supervised: false
 mobileconfig: true

--- a/rules/os/os_allow_documents_managed_sources_unmanaged_destinations_disable.yaml
+++ b/rules/os/os_allow_documents_managed_sources_unmanaged_destinations_disable.yaml
@@ -20,7 +20,8 @@ references:
     - 'FMT_SMF_EXT.1.1 #42'
     - 'FDP_ACF_EXT.1.2'
   disa_stig:
-    - N/A
+    - AIOS-17-009700
+    - AIOS-17-709700
   800-171r2:
     - N/A
   cis:
@@ -41,6 +42,8 @@ tags:
   - cis_lvl1_enterprise
   - cis_lvl2_enterprise
   - cisv8
+  - ios_stig
+  - ios_stig_byoad
 severity: "medium"
 supervised: false
 mobileconfig: true

--- a/rules/os/os_allow_documents_unmanaged_sources_managed_destinations_disable.yaml
+++ b/rules/os/os_allow_documents_unmanaged_sources_managed_destinations_disable.yaml
@@ -18,7 +18,7 @@ references:
   sfr:
     - N/A
   disa_stig:
-    - N/A
+    - AIOS-17-714900
   800-171r2:
     - N/A
   cis:
@@ -39,6 +39,7 @@ tags:
   - cis_lvl1_enterprise
   - cis_lvl2_enterprise
   - cisv8
+  - ios_stig_byoad
 supervised: false
 mobileconfig: true
 mobileconfig_info:

--- a/rules/os/os_apple_watch_pairing_disable.yaml
+++ b/rules/os/os_apple_watch_pairing_disable.yaml
@@ -19,7 +19,7 @@ references:
   sfr:
     - 'FMT_SMF_EXT.1.1 #47'
   disa_stig:
-    - N/A
+    - AIOS-17-012600
   800-171r2:
     - N/A
   cis:
@@ -34,6 +34,7 @@ tags:
   - 800-53r5_low
   - 800-53r5_moderate
   - 800-53r5_high
+  - ios_stig
 severity: medium
 supervised: true
 mobileconfig: true

--- a/rules/os/os_apple_watch_wrist_detection_enable.yaml
+++ b/rules/os/os_apple_watch_wrist_detection_enable.yaml
@@ -17,7 +17,8 @@ references:
   sfr:
     - 'FMT_SMF_EXT.1.1 #47'
   disa_stig:
-    - N/A
+    - AIOS-17-011800
+    - AIOS-17-711800
   800-171r2:
     - N/A
   cis:
@@ -38,6 +39,8 @@ tags:
   - cis_lvl1_enterprise
   - cis_lvl2_enterprise
   - cisv8
+  - ios_stig
+  - ios_stig_byoad
 severity: "low"
 supervised: false
 mobileconfig: true

--- a/rules/os/os_application_allow_list.yaml
+++ b/rules/os/os_application_allow_list.yaml
@@ -23,7 +23,8 @@ references:
   sfr:
     - 'FMT_SMF_EXT.1.1 #8b'
   disa_stig:
-    - N/A
+    - AIOS-17-007400
+    - AIOS-17-707400
   800-171r2:
     - N/A
   cis:
@@ -38,6 +39,8 @@ tags:
   - 800-53r5_moderate
   - 800-53r5_high
   - manual
+  - ios_stig
+  - ios_stig_byoad
 severity: medium
 supervised: true
 mobileconfig: false # Set to true when implementing

--- a/rules/os/os_auto_unlock_disable.yaml
+++ b/rules/os/os_auto_unlock_disable.yaml
@@ -17,7 +17,7 @@ references:
   sfr:
     - 'FMT_MOF_EXT.1.2 #47'
   disa_stig:
-    - N/A
+    - AIOS-17-014800
   800-171r2:
     - N/A
   cis:
@@ -31,6 +31,7 @@ tags:
   - ios
   - 800-53r5_moderate
   - 800-53r5_high
+  - ios_stig
 severity: medium
 supervised: false
 mobileconfig: true

--- a/rules/os/os_diagnostics_reports_disable.yaml
+++ b/rules/os/os_diagnostics_reports_disable.yaml
@@ -19,7 +19,8 @@ references:
   sfr:
     - 'FMT_SMF_EXT.1.1 #47a'
   disa_stig:
-    - N/A
+    - AIOS-17-013400
+    - AIOS-17-713400
   800-171r2:
     - N/A
   cis:
@@ -40,6 +41,8 @@ tags:
   - cis_lvl1_enterprise
   - cis_lvl2_enterprise
   - cisv8
+  - ios_stig
+  - ios_stig_byoad
 severity: "medium"
 supervised: false
 mobileconfig: true

--- a/rules/os/os_disallow_enterprise_app_trust.yaml
+++ b/rules/os/os_disallow_enterprise_app_trust.yaml
@@ -14,7 +14,8 @@ references:
   sfr:
     - 'FMT_SMF_EXT.1.1 #8a'
   disa_stig:
-    - N/A
+    - AIOS-17-007000
+    - AIOS-17-707000
   800-171r2:
     - N/A
   cis:
@@ -29,6 +30,8 @@ tags:
   - 800-53r5_low
   - 800-53r5_moderate
   - 800-53r5_high
+  - ios_stig
+  - ios_stig_byoad
 severity: low
 supervised: false
 mobileconfig: true

--- a/rules/os/os_enterprise_books_disable.yaml
+++ b/rules/os/os_enterprise_books_disable.yaml
@@ -15,7 +15,8 @@ references:
   sfr:
     - 'FMT_MOF_EXT.1.2 #40'
   disa_stig:
-    - N/A
+    - AIOS-17-003700
+    - AIOS-17-703700
   800-171r2:
     - N/A
   cis:
@@ -27,6 +28,8 @@ iOS:
   - "17.0"
 tags:
   - ios
+  - ios_stig
+  - ios_stig_byoad
 severity: "medium"
 supervised: false
 mobileconfig: true

--- a/rules/os/os_files_network_drive_access_disable.yaml
+++ b/rules/os/os_files_network_drive_access_disable.yaml
@@ -17,7 +17,7 @@ references:
   sfr:
     - 'FMT_SMF_EXT.1.1 #47'
   disa_stig:
-    - N/A
+    - AIOS-17-014300
   800-171r2:
     - N/A
   cis:
@@ -33,6 +33,7 @@ tags:
   - 800-53r5_high
   - cis_lvl2_enterprise
   - cisv8
+  - ios_stig
 severity: "medium"
 supervised: true
 mobileconfig: true

--- a/rules/os/os_files_usb_drive_access_disable.yaml
+++ b/rules/os/os_files_usb_drive_access_disable.yaml
@@ -19,7 +19,7 @@ references:
   sfr:
     - 'FMT_SMF_EXT.1.1 #47'
   disa_stig:
-    - N/A
+    - AIOS-17-013300
   800-171r2:
     - N/A
   cis:
@@ -35,6 +35,7 @@ tags:
   - 800-53r5_high
   - cis_lvl2_enterprise
   - cisv8
+  - ios_stig
 severity: "medium"
 supervised: true
 mobileconfig: true

--- a/rules/os/os_find_my_friends_disable.yaml
+++ b/rules/os/os_find_my_friends_disable.yaml
@@ -20,7 +20,7 @@ references:
   sfr:
     - 'FMT_SMF_EXT.1.1 #47'
   disa_stig:
-    - N/A
+    - AIOS-17-013100
   800-171r2:
     - N/A
   cis:
@@ -35,6 +35,7 @@ tags:
   - 800-53r5_low
   - 800-53r5_moderate
   - 800-53r5_high
+  - ios_stig
 severity: low
 supervised: true
 mobileconfig: true

--- a/rules/os/os_force_encrypted_backups_enable.yaml
+++ b/rules/os/os_force_encrypted_backups_enable.yaml
@@ -20,7 +20,8 @@ references:
   sfr:
     - 'FMT_SMF_EXT.1.1 #47'
   disa_stig:
-    - N/A
+    - AIOS-17-010700
+    - AIOS-17-710700
   800-171r2:
     - N/A
   cis:
@@ -41,6 +42,8 @@ tags:
   - cis_lvl1_enterprise
   - cis_lvl2_enterprise
   - cisv8
+  - ios_stig
+  - ios_stig_byoad
 severity: "medium"
 supervised: false
 mobileconfig: true

--- a/rules/os/os_handoff_disable.yaml
+++ b/rules/os/os_handoff_disable.yaml
@@ -20,7 +20,7 @@ references:
     - CM-7
     - CM-7(1)
   disa_stig:
-    - N/A
+    - AIOS-17-010800
   sfr:
     - 'FMT_SMF_EXT.1.1 #47'
   800-171r2:
@@ -41,6 +41,7 @@ tags:
   - cis_lvl2_byod
   - cis_lvl2_enterprise
   - cisv8
+  - ios_stig
 severity: "low"
 supervised: false
 mobileconfig: true

--- a/rules/os/os_install_vpn_configuration_disable.yaml
+++ b/rules/os/os_install_vpn_configuration_disable.yaml
@@ -21,7 +21,8 @@ references:
   sfr:
     - 'FMT_SMF_EXT.1.1 #3'
   disa_stig:
-    - N/A
+    - AIOS-17-001000
+    - AIOS-17-701000
   800-171r2:
     - N/A
   cis:
@@ -39,6 +40,8 @@ tags:
   - cis_lvl1_enterprise
   - cis_lvl2_enterprise
   - cisv8
+  - ios_stig
+  - ios_stig_byoad
 severity: "low"
 supervised: true
 mobileconfig: true

--- a/rules/os/os_iphone_widgets_on_mac_disable.yaml
+++ b/rules/os/os_iphone_widgets_on_mac_disable.yaml
@@ -7,7 +7,7 @@ fix: |
   This is implemented by a Configuration Profile.
 references:
   cce:
-    - CCE-93
+    - N/A
   cci:
     - CCI-000366
   800-53r5:

--- a/rules/os/os_iphone_widgets_on_mac_disable.yaml
+++ b/rules/os/os_iphone_widgets_on_mac_disable.yaml
@@ -1,4 +1,4 @@
-id: os_iphone_widgets_on_mac
+id: os_iphone_widgets_on_mac_disable
 title: "Disable use of iPhone widgets on Mac"
 discussion: |
   iPhone widgets on Mac _MUST_ be disabled.

--- a/rules/os/os_iphone_widgets_on_mac_disable.yaml
+++ b/rules/os/os_iphone_widgets_on_mac_disable.yaml
@@ -1,0 +1,36 @@
+id: os_iphone_widgets_on_mac
+title: "Disable use of iPhone widgets on Mac"
+discussion: |
+  iPhone widgets on Mac _MUST_ be disabled.
+check: " "
+fix: |
+  This is implemented by a Configuration Profile.
+references:
+  cce:
+    - CCE-93
+  cci:
+    - CCI-000366
+  800-53r5:
+    - CM-7
+    - CM-7(1)
+  sfr:
+    - 'FMT_SMF_EXT.1.1 #8b'
+  disa_stig:
+    - AIOS-17-010850
+  800-171r2:
+    - N/A
+  cis:
+    benchmark:
+      - N/A
+    controls v8:
+      - N/A
+iOS:
+  - "17.0"
+tags:
+  - ios
+  - ios_stig
+supervised: true
+mobileconfig: true
+mobileconfig_info:
+  com.apple.applicationaccess:
+    allowiPhoneWidgetsOnMac: false

--- a/rules/os/os_limit_ad_tracking_enable.yaml
+++ b/rules/os/os_limit_ad_tracking_enable.yaml
@@ -21,7 +21,7 @@ references:
   sfr:
     - 'FMT_SMF_EXT.1.1 #47'
   disa_stig:
-    - N/A
+    - AIOS-17-010500
   800-171r2:
     - N/A
   cis:
@@ -37,6 +37,7 @@ tags:
   - 800-53r5_moderate
   - 800-53r5_high
   - cisv8
+  - ios_stig
 severity: low
 supervised: false
 mobileconfig: true

--- a/rules/os/os_mail_maildrop_disable.yaml
+++ b/rules/os/os_mail_maildrop_disable.yaml
@@ -21,7 +21,7 @@ references:
   sfr:
     - 'FMT_SMF_EXT.1.1 #47'
   disa_stig:
-    - N/A
+    - AIOS-17-011000
   800-171r2:
     - N/A
   cis:
@@ -40,6 +40,7 @@ tags:
   - cis_lvl2_byod
   - cis_lvl2_enterprise
   - cisv8
+  - ios_stig
 severity: "medium"
 supervised: false
 mobileconfig: true

--- a/rules/os/os_mail_move_messages_disable.yaml
+++ b/rules/os/os_mail_move_messages_disable.yaml
@@ -21,7 +21,8 @@ references:
   sfr:
     - 'FMT_SMF_EXT.1.1 #47'
   disa_stig:
-    - N/A
+    - AIOS-17-011400
+    - AIOS-17-711400
   800-171r2:
     - N/A
   cis:
@@ -42,6 +43,8 @@ tags:
   - cis_lvl1_enterprise
   - cis_lvl2_enterprise
   - cisv8
+  - ios_stig
+  - ios_stig_byoad
 severity: "medium"
 supervised: false
 mobileconfig: true

--- a/rules/os/os_new_device_proximity_disable.yaml
+++ b/rules/os/os_new_device_proximity_disable.yaml
@@ -19,7 +19,7 @@ references:
   sfr:
     - 'FMT_SMF_EXT.1.1 #47'
   disa_stig:
-    - N/A
+    - AIOS-17-012800
   800-171r2:
     - N/A
   cis:
@@ -37,6 +37,7 @@ tags:
   - cis_lvl1_enterprise
   - cis_lvl2_enterprise
   - cisv8
+  - ios_stig
 severity: "medium"
 supervised: true
 mobileconfig: true

--- a/rules/os/os_on_device_dictation_enforce.yaml
+++ b/rules/os/os_on_device_dictation_enforce.yaml
@@ -20,7 +20,7 @@ references:
   sfr:
     - 'FMT_SMF_EXT.1.1 #47'
   disa_stig:
-    - N/A
+    - AIOS-17-014400
   800-171r2:
     - N/A
   cis:
@@ -35,6 +35,7 @@ tags:
   - 800-53r5_low
   - 800-53r5_moderate
   - 800-53r5_high
+  - ios_stig
 severity: medium
 supervised: false
 mobileconfig: true

--- a/rules/os/os_on_device_translation_enforce.yaml
+++ b/rules/os/os_on_device_translation_enforce.yaml
@@ -20,7 +20,7 @@ references:
   sfr:
     - 'FMT_SMF_EXT.1.1 #47'
   disa_stig:
-    - N/A
+    - AIOS-17-014500
   800-171r2:
     - N/A
   cis:
@@ -35,6 +35,7 @@ tags:
   - 800-53r5_low
   - 800-53r5_moderate
   - 800-53r5_high
+  - ios_stig
 severity: medium
 supervised: false
 mobileconfig: true

--- a/rules/os/os_password_autofill_disable.yaml
+++ b/rules/os/os_password_autofill_disable.yaml
@@ -22,7 +22,7 @@ references:
   sfr:
     - 'FMT_SMF_EXT.1.1 #47'
   disa_stig:
-    - N/A
+    - AIOS-17-012700
   800-171r2:
     - N/A
   cis:
@@ -37,6 +37,7 @@ tags:
   - 800-53r5_low
   - 800-53r5_moderate
   - 800-53r5_high
+  - ios_stig
 severity: medium
 supervised: true
 mobileconfig: true

--- a/rules/os/os_password_proximity_disable.yaml
+++ b/rules/os/os_password_proximity_disable.yaml
@@ -19,7 +19,7 @@ references:
   sfr:
     - 'FMT_SMF_EXT.1.1 #47'
   disa_stig:
-    - N/A
+    - AIOS-17-012900
   800-171r2:
     - N/A
   cis:
@@ -37,6 +37,7 @@ tags:
   - cis_lvl1_enterprise
   - cis_lvl2_enterprise
   - cisv8
+  - ios_stig
 severity: "medium"
 supervised: true
 mobileconfig: true

--- a/rules/os/os_password_sharing_disable.yaml
+++ b/rules/os/os_password_sharing_disable.yaml
@@ -18,7 +18,7 @@ references:
   sfr:
     - 'FMT_SMF_EXT.1.1 #47'
   disa_stig:
-    - N/A
+    - AIOS-17-013000
   800-171r2:
     - N/A
   cis:
@@ -33,6 +33,7 @@ tags:
   - 800-53r5_low
   - 800-53r5_moderate
   - 800-53r5_high
+  - ios_stig
 severity: medium
 supervised: true
 mobileconfig: true

--- a/rules/os/os_require_managed_pasteboard_enforce.yaml
+++ b/rules/os/os_require_managed_pasteboard_enforce.yaml
@@ -19,7 +19,8 @@ references:
   sfr:
     - 'FMT_SMF_EXT.1.1 #47'
   disa_stig:
-    - N/A
+    - AIOS-17-014600
+    - AIOS-17-714600
   800-171r2:
     - N/A
   cis:
@@ -31,6 +32,8 @@ iOS:
   - "17.0"
 tags:
   - ios
+  - ios_stig
+  - ios_stig_byoad
 severity: medium
 supervised: false
 mobileconfig: true

--- a/rules/os/os_safari_password_autofill_disable.yaml
+++ b/rules/os/os_safari_password_autofill_disable.yaml
@@ -21,7 +21,7 @@ references:
   sfr:
     - 'FMT_SMF_EXT.1.1 #47'
   disa_stig:
-    - N/A
+    - AIOS-17-010600
   800-171r2:
     - N/A
   cis:
@@ -38,6 +38,7 @@ tags:
   - 800-53r5_moderate
   - 800-53r5_high
   - cisv8
+  - ios_stig
 severity: "low"
 supervised: true
 mobileconfig: true

--- a/rules/os/os_share_location_data_disable.yaml
+++ b/rules/os/os_share_location_data_disable.yaml
@@ -14,7 +14,7 @@ references:
   sfr:
     - 'FMT_SMF_EXT.1.1 #47'
   disa_stig:
-    - N/A
+    - AIOS-17-011700
   800-171r2:
     - N/A
   cis:
@@ -30,6 +30,7 @@ tags:
   - 800-53r5_moderate
   - 800-53r5_high
   - manual
+  - ios_stig
 severity: medium
 supervised: false
 mobileconfig: false

--- a/rules/os/os_show_calendar_lock_screen_disable.yaml
+++ b/rules/os/os_show_calendar_lock_screen_disable.yaml
@@ -14,7 +14,8 @@ references:
   sfr:
     - 'FMT_SMF_EXT.1.1 #18'
   disa_stig:
-    - N/A
+    - AIOS-17-007600
+    - AIOS-17-707600
   800-171r2:
     - N/A
   cis:
@@ -28,6 +29,8 @@ tags:
   - ios
   - 800-53r5_moderate
   - 800-53r5_high
+  - ios_stig
+  - ios_stig_byoad
 severity: medium
 supervised: false
 mobileconfig: true

--- a/rules/os/os_show_notification_center_lock_screen_disable.yaml
+++ b/rules/os/os_show_notification_center_lock_screen_disable.yaml
@@ -15,7 +15,8 @@ references:
   sfr:
     - 'FMT_SMF_EXT.1.1 #18'
   disa_stig:
-    - N/A
+    - AIOS-17-007600
+    - AIOS-17-707600
   800-171r2:
     - N/A
   cis:
@@ -35,6 +36,8 @@ tags:
   - cis_lvl1_enterprise
   - cis_lvl2_enterprise
   - cisv8
+  - ios_stig
+  - ios_stig_byoad
 severity: "medium"
 supervised: false
 mobileconfig: true

--- a/rules/os/os_siri_when_locked_disabled.yaml
+++ b/rules/os/os_siri_when_locked_disabled.yaml
@@ -18,7 +18,7 @@ references:
   sfr:
     - 'FMT_SMF_EXT.1.1 #8b'
   disa_stig:
-    - N/A
+    - AIOS-17-007200
   800-171r2:
     - N/A
   cis:
@@ -39,6 +39,7 @@ tags:
   - cis_lvl1_enterprise
   - cis_lvl2_enterprise
   - cisv8
+  - ios_stig
 severity: "medium"
 supervised: false
 mobileconfig: true

--- a/rules/os/os_ssl_for_exchange_activesync_enable.yaml
+++ b/rules/os/os_ssl_for_exchange_activesync_enable.yaml
@@ -14,7 +14,8 @@ references:
   sfr:
     - 'FMT_SMF_EXT.1.1 #47'
   disa_stig:
-    - N/A
+    - AIOS-17-011300
+    - AIOS-17-711300
   800-171r2:
     - N/A
   cis:
@@ -26,6 +27,8 @@ iOS:
   - "17.0"
 tags:
   - ios
+  - ios_stig
+  - ios_stig_byoad
 severity: medium
 supervised: false
 mobileconfig: true

--- a/rules/os/os_supervised_mdm_require.yaml
+++ b/rules/os/os_supervised_mdm_require.yaml
@@ -17,7 +17,7 @@ references:
   sfr:
     - 'FMT_SMF_EXT.1.1 #47'
   disa_stig:
-    - N/A
+    - AIOS-17-013200
   800-171r2:
     - N/A
   cis:
@@ -33,6 +33,7 @@ tags:
   - 800-53r5_low
   - 800-53r5_moderate
   - 800-53r5_high
+  - ios_stig
 severity: medium
 mobileconfig: false
 mobileconfig_info:

--- a/rules/os/os_usb_accessories_when_locked_disable.yaml
+++ b/rules/os/os_usb_accessories_when_locked_disable.yaml
@@ -20,7 +20,7 @@ references:
   sfr:
     - 'FMT_SMF_EXT.1.1 #47'
   disa_stig:
-    - N/A
+    - AIOS-17-012200
   800-171r2:
     - N/A
   cis:
@@ -38,9 +38,10 @@ tags:
   - cis_lvl1_enterprise
   - cis_lvl2_enterprise
   - cisv8
+  - ios_stig
 severity: "medium"
 supervised: true
 mobileconfig: true
 mobileconfig_info:
   com.apple.applicationaccess:
-    allowUSBRestrictedMode: false
+    allowUSBRestrictedMode: true

--- a/rules/pwpolicy/pwpolicy_account_lockout_enforce.yaml
+++ b/rules/pwpolicy/pwpolicy_account_lockout_enforce.yaml
@@ -18,7 +18,8 @@ references:
     - 'FMT_SMF_EXT.1.1 #2c'
     - 'FIA_AFL_EXT.1.5'
   disa_stig:
-    - N/A
+    - AIOS-17-006900
+    - AIOS-17-706900
   800-171r2:
     - N/A
   cis:
@@ -47,6 +48,8 @@ tags:
   - cis_lvl1_enterprise
   - cis_lvl2_enterprise
   - cisv8
+  - ios_stig
+  - ios_stig_byoad
 severity: "medium"
 supervised: false
 mobileconfig: true

--- a/rules/pwpolicy/pwpolicy_account_lockout_enforce.yaml
+++ b/rules/pwpolicy/pwpolicy_account_lockout_enforce.yaml
@@ -38,6 +38,7 @@ odv:
   cis_lvl1_enterprise: 6
   cis_lvl2_enterprise: 6  
   ios_stig: 10
+  ios_stig_byoad: 10
 tags:
   - ios
   - 800-53r5_low

--- a/rules/pwpolicy/pwpolicy_force_pin_enable.yaml
+++ b/rules/pwpolicy/pwpolicy_force_pin_enable.yaml
@@ -16,7 +16,8 @@ references:
   sfr:
     - 'FIA_UAU_EXT.1.1'
   disa_stig:
-    - N/A
+    - AIOS-17-010400
+    - AIOS-17-710400
   800-171r2:
     - N/A
   cis:
@@ -28,6 +29,8 @@ iOS:
   - "17.0"
 tags:
   - ios
+  - ios_stig
+  - ios_stig_byoad
 severity: high
 mobileconfig: 'true'
 mobileconfig_info:

--- a/rules/pwpolicy/pwpolicy_max_grace_period_enforce.yaml
+++ b/rules/pwpolicy/pwpolicy_max_grace_period_enforce.yaml
@@ -16,7 +16,8 @@ references:
   sfr:
     - 'FMT_SMF_EXT.1.1 #2a'
   disa_stig:
-    - N/A
+    - AIOS-17-006700
+    - AIOS-17-706700
   800-171r2:
     - N/A
   cis:
@@ -35,6 +36,7 @@ odv:
   cis_lvl1_enterprise: 0
   cis_lvl2_enterprise: 0
   ios_stig: 5
+  ios_stig_byoad: 5
 tags:
   - ios
   - 800-53r5_low
@@ -45,6 +47,8 @@ tags:
   - cis_lvl1_enterprise
   - cis_lvl2_enterprise
   - cisv8
+  - ios_stig
+  - ios_stig_byoad
 severity: "medium"
 supervised: false
 mobileconfig: true

--- a/rules/pwpolicy/pwpolicy_max_inactivity_enforce.yaml
+++ b/rules/pwpolicy/pwpolicy_max_inactivity_enforce.yaml
@@ -16,7 +16,8 @@ references:
   sfr:
     - 'FMT_SMF_EXT.1.1 #2b'
   disa_stig:
-    - N/A
+    - AIOS-17-006800
+    - AIOS-17-706800
   800-171r2:
     - N/A
   cis:
@@ -35,6 +36,7 @@ odv:
   cis_lvl1_enterprise: 2
   cis_lvl2_enterprise: 2
   ios_stig: 5
+  ios_stig_byoad: 5
 tags:
   - ios
   - 800-53r5_low
@@ -45,6 +47,8 @@ tags:
   - cis_lvl1_enterprise
   - cis_lvl2_enterprise
   - cisv8
+  - ios_stig
+  - ios_stig_byoad
 severity: "medium"
 supervised: false
 mobileconfig: true

--- a/rules/pwpolicy/pwpolicy_minimum_length_enforce.yaml
+++ b/rules/pwpolicy/pwpolicy_minimum_length_enforce.yaml
@@ -17,7 +17,8 @@ references:
   sfr:
     - 'FMT_SMF_EXT.1.1 #1a'
   disa_stig:
-    - N/A
+    - AIOS-17-006500
+    - AIOS-17-706500
   800-171r2:
     - N/A
   cis:
@@ -36,6 +37,7 @@ odv:
   cis_lvl1_enterprise: 6
   cis_lvl2_enterprise: 6
   ios_stig: 6
+  ios_stig_byoad: 6
 tags:
   - ios
   - 800-53r5_low
@@ -46,6 +48,8 @@ tags:
   - cis_lvl1_enterprise
   - cis_lvl2_enterprise
   - cisv8
+  - ios_stig
+  - ios_stig_byoad
 severity: "medium"
 supervised: false
 mobileconfig: true

--- a/rules/pwpolicy/pwpolicy_simple_sequence_disable.yaml
+++ b/rules/pwpolicy/pwpolicy_simple_sequence_disable.yaml
@@ -17,7 +17,8 @@ references:
   sfr:
     - 'FMT_SMF_EXT.1.1 #1b'
   disa_stig:
-    - N/A
+    - AIOS-17-006600
+    - AIOS-17-706600
   800-171r2:
     - N/A
   cis:
@@ -38,6 +39,8 @@ tags:
   - cis_lvl1_enterprise
   - cis_lvl2_enterprise
   - cisv8
+  - ios_stig
+  - ios_stig_byoad
 severity: "medium"
 supervised: false
 mobileconfig: true

--- a/rules/supplemental/supplemental_stig.yaml
+++ b/rules/supplemental/supplemental_stig.yaml
@@ -10,26 +10,27 @@ discussion: |
   |STIG ID
   |Rule Title
 
-  |AIOS-16-004900| Apple iOS/iPadOS 16 must [selection: wipe protected data, wipe sensitive data] upon unenrollment from MDM.
-  |AIOS-16-005000| Apple iOS/iPadOS 16 must [selection: remove Enterprise application, remove all noncore applications (any nonfactory-installed application)] upon unenrollment from MDM.
-  |AIOS-16-007400 +
-  AIOS-16-707400| Apple iOS/iPadOS 16 allowlist must be configured to not include applications with the following characteristics: - Backs up MD data to non-DoD cloud servers (including user and application access to cloud backup services); - Transmits MD diagnostic data to non-DoD servers; - Allows synchronization of data or applications between devices associated with user; and - Allows unencrypted (or encrypted but not FIPS 140-2/FIPS 140-3 validated) data sharing with other MDs or printers.
-  |AIOS-16-008400 +
-  AIOS-16-708400| Apple iOS/iPadOS 16 must be configured to display the DoD advisory warning message at startup or each time the user unlocks the device.
-  |AIOS-16-009200 +
-  AIOS-16-709200| Apple iOS/iPadOS 16 must be configured to not allow backup of [all applications, configuration data] to locally connected systems.
-  |AIOS-16-009800| Apple iOS/iPadOS 16 must be configured to disable multiuser modes.
-  |AIOS-16-009900 +
-  AIOS-16-709900| Apple iOS/iPadOS 16 must be configured to [selection: wipe protected data, wipe sensitive data] upon unenrollment from MDM.
-  |AIOS-16-010000|  Apple iOS/iPadOS 16 must be configured to [selection: remove Enterprise applications, remove all noncore applications (any nonfactory installed application)] upon unenrollment from MDM.
-  |AIOS-16-011200 +
-  AIOS-16-711200| iPhone and iPad must have the latest available iOS/iPadOS operating system installed.
-  |AIOS-16-011600| Apple iOS/iPadOS 16 must implement the management setting: Not have any Family Members in Family Sharing.
-  |AIOS-16-011900 +
-  AIOS-16-711900| Apple iOS/iPadOS 16 users must complete required training.
-  |AIOS-16-012000 +
-  AIOS-16-712000| A managed photo app must be used to take and store work-related photos.
-  |AIOS-16-013500| Apple iOS must implement the management setting: Not allow a user to remove Apple iOS configuration profiles that enforce DoD security requirements.
+  |AIOS-17-004900| Apple iOS/iPadOS 17 must [selection: wipe protected data, wipe sensitive data] upon unenrollment from MDM.
+  |AIOS-17-005000| Apple iOS/iPadOS 17 must [selection: remove Enterprise application, remove all noncore applications (any nonfactory-installed application)] upon unenrollment from MDM.
+  |AIOS-17-007400 +
+  AIOS-17-707400| Apple iOS/iPadOS 17 allowlist must be configured to not include applications with the following characteristics: - Backs up MD data to non-DoD cloud servers (including user and application access to cloud backup services); - Transmits MD diagnostic data to non-DoD servers; - Allows synchronization of data or applications between devices associated with user; and - Allows unencrypted (or encrypted but not FIPS 140-2/FIPS 140-3 validated) data sharing with other MDs or printers.
+  |AIOS-17-008400 +
+  AIOS-17-708400| Apple iOS/iPadOS 17 must be configured to display the DoD advisory warning message at startup or each time the user unlocks the device.
+  |AIOS-17-009200 +
+  AIOS-17-709200| Apple iOS/iPadOS 17 must be configured to not allow backup of [all applications, configuration data] to locally connected systems.
+  |AIOS-17-009800| Apple iOS/iPadOS 17 must be configured to disable multiuser modes.
+  |AIOS-17-009900 +
+  AIOS-17-709900| Apple iOS/iPadOS 17 must be configured to [selection: wipe protected data, wipe sensitive data] upon unenrollment from MDM.
+  |AIOS-17-010000|  Apple iOS/iPadOS 17 must be configured to [selection: remove Enterprise applications, remove all noncore applications (any nonfactory installed application)] upon unenrollment from MDM.
+  |AIOS-17-011200 +
+  AIOS-17-711200| iPhone and iPad must have the latest available iOS/iPadOS operating system installed.
+  |AIOS-17-011600| Apple iOS/iPadOS 17 must implement the management setting: Not have any Family Members in Family Sharing.
+  |AIOS-17-011900 +
+  AIOS-17-711900| Apple iOS/iPadOS 17 users must complete required training.
+  |AIOS-17-012000 +
+  AIOS-17-712000| A managed photo app must be used to take and store work-related photos.
+  |AIOS-17-012650| Apple iOS/iPadOS 17 must implement the management setting: approved Apple Watches must be managed by an MDM.
+  |AIOS-17-013500| Apple iOS must implement the management setting: Not allow a user to remove Apple iOS configuration profiles that enforce DoD security requirements.
   |===
 check: |
 fix: |
@@ -45,9 +46,10 @@ references:
   disa_stig:
     - N/A
 iOS:
-  - "13.0"
+  - "17.0"
 tags:
   - ios_stig
+  - ios_stig_byoad
   - supplemental
 mobileconfig: false
 mobileconfig_info:  


### PR DESCRIPTION
Updated rule .yaml files for iOS 17 icloud, os, and pwpolicy rules to include STIG IDs and tags.