### PR TITLE
Fix dependency issue in rexml module in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'rexml', '3.2.6'
+gem 'rexml', '3.3.9'
 gem 'asciidoctor', '2.0.22'
 gem 'asciidoctor-pdf'
 gem 'rouge', '3.30.0'

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'rexml', '3.3.9'
 gem 'asciidoctor', '2.0.22'
 gem 'asciidoctor-pdf'
 gem 'rouge', '3.30.0'


### PR DESCRIPTION
rexml version used in Gemfile is out of date and has security vulnerabilities which should be patched. Please see the dependabot findings when I ran it on my forked repo after upgrading the version number to 3.3.9

