### PR TITLE
Improve regex code

### DIFF
--- a/scripts/generate_guidance.py
+++ b/scripts/generate_guidance.py
@@ -126,7 +126,7 @@ def get_check_code(check_yaml):
     except:
         return check_yaml
     # print check_string
-    check_code = re.search("(?:----((?:.*?\r?\n?)*)----)+", check_string)
+    check_code = re.search(r"----\n?(.*?)\n?----", check_string, re.DOTALL)
     # print(check_code.group(1).rstrip())
     return check_code.group(1).strip()
 
@@ -140,7 +140,7 @@ def quotify(fix_code):
 
 def get_fix_code(fix_yaml):
     fix_string = fix_yaml.split("[source,bash]")[1]
-    fix_code = re.search("(?:----((?:.*?\r?\n?)*)----)+", fix_string)
+    fix_code = re.search(r"----\n?(.*?)\n?----", fix_string, re.DOTALL)
     return fix_code.group(1)
 
 


### PR DESCRIPTION
I found two code scanning alerts for the repo which should be fixed to help improve static code analysis security results for the repo.

Alert 1.
![image](https://github.com/user-attachments/assets/5266c0fc-1cf7-451e-8d18-5ca7b2d5b99c)

Alert 2.
![image](https://github.com/user-attachments/assets/cc39585d-ed91-4c35-af4b-e88affe38ab2)
