### PR TITLE
Update generate_baseline.py

### DIFF
--- a/scripts/generate_baseline.py
+++ b/scripts/generate_baseline.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# filename: generate_guidance.py
+# filename: generate_baseline.py
 # description: Process a given keyword, and output a baseline file
 
 import os.path


### PR DESCRIPTION
### Why
- To fix filename mismatch

### What Changed?
- changed the file name from `generate_guidance.py` to `generate_baseline.py` to match the scripts name

### Related PRs:
- https://github.com/usnistgov/macos_security/pull/492