### PR TITLE
Fix CIS reference numbers being off by 1 in system_settings.general.s…

### DIFF
--- a/rules/supplemental/supplemental_cis_manual.yaml
+++ b/rules/supplemental/supplemental_cis_manual.yaml
@@ -15,7 +15,7 @@ discussion: |
   2.1.1.5 Audit Freeform Sync to iCloud +
   2.1.1.6 Audit Find My Mac +
   2.1.2 Audit App Store Password Settings +
-  2.3.3.12 Ensure Computer Name Does Not Contain PII or Protected Organizational Information +
+  2.3.3.11 Ensure Computer Name Does Not Contain PII or Protected Organizational Information +
   2.5.1 Audit Siri Settings +
   2.6.1.3 Audit Location Services Access +
   2.6.2.1 Audit Full Disk Access for Applications +

--- a/rules/system_settings/system_settings_bluetooth_sharing_disable.yaml
+++ b/rules/system_settings/system_settings_bluetooth_sharing_disable.yaml
@@ -47,7 +47,7 @@ references:
     - 03.04.06
   cis:
     benchmark:
-      - 2.3.3.11 (level 1)
+      - 2.3.3.10 (level 1)
     controls v8:
       - 3.3
       - 4.1

--- a/rules/system_settings/system_settings_content_caching_disable.yaml
+++ b/rules/system_settings/system_settings_content_caching_disable.yaml
@@ -32,7 +32,7 @@ references:
     - 03.04.06
   cis:
     benchmark:
-      - 2.3.3.9 (level 2)
+      - 2.3.3.8 (level 2)
     controls v8:
       - 4.8
   cmmc:

--- a/rules/system_settings/system_settings_internet_sharing_disable.yaml
+++ b/rules/system_settings/system_settings_internet_sharing_disable.yaml
@@ -33,7 +33,7 @@ references:
     - 03.01.20
   cis:
     benchmark:
-      - 2.3.3.8 (level 1)
+      - 2.3.3.7 (level 1)
     controls v8:
       - 4.1
       - 4.8

--- a/rules/system_settings/system_settings_media_sharing_disabled.yaml
+++ b/rules/system_settings/system_settings_media_sharing_disabled.yaml
@@ -48,7 +48,7 @@ references:
     - 03.04.06
   cis:
     benchmark:
-      - 2.3.3.10 (level 2)
+      - 2.3.3.9 (level 2)
     controls v8:
       - 4.1
       - 4.8

--- a/rules/system_settings/system_settings_printer_sharing_disable.yaml
+++ b/rules/system_settings/system_settings_printer_sharing_disable.yaml
@@ -31,7 +31,7 @@ references:
     - 03.04.06
   cis:
     benchmark:
-      - 2.3.3.4 (level 1)
+      - 2.3.3.3 (level 1)
     controls v8:
       - 4.1
       - 4.8

--- a/rules/system_settings/system_settings_rae_disable.yaml
+++ b/rules/system_settings/system_settings_rae_disable.yaml
@@ -37,7 +37,7 @@ references:
     - 03.04.06
   cis:
     benchmark:
-      - 2.3.3.7 (level 1)
+      - 2.3.3.6 (level 1)
     controls v8:
       - 4.1
       - 4.8

--- a/rules/system_settings/system_settings_remote_management_disable.yaml
+++ b/rules/system_settings/system_settings_remote_management_disable.yaml
@@ -33,7 +33,7 @@ references:
     - 03.04.06
   cis:
     benchmark:
-      - 2.3.3.6 (level 1)
+      - 2.3.3.5 (level 1)
     controls v8:
       - 4.1
       - 4.8

--- a/rules/system_settings/system_settings_screen_sharing_disable.yaml
+++ b/rules/system_settings/system_settings_screen_sharing_disable.yaml
@@ -35,7 +35,7 @@ references:
     - 03.04.06
   cis:
     benchmark:
-      - 2.3.3.2 (level 1)
+      - 2.3.3.1 (level 1)
     controls v8:
       - 4.1
       - 4.8

--- a/rules/system_settings/system_settings_smbd_disable.yaml
+++ b/rules/system_settings/system_settings_smbd_disable.yaml
@@ -34,7 +34,7 @@ references:
     - 03.04.06
   cis:
     benchmark:
-      - 2.3.3.3 (level 1)
+      - 2.3.3.2 (level 1)
     controls v8:
       - 4.1
       - 4.8

--- a/rules/system_settings/system_settings_ssh_disable.yaml
+++ b/rules/system_settings/system_settings_ssh_disable.yaml
@@ -35,7 +35,7 @@ references:
     - 03.04.06
   cis:
     benchmark:
-      - 2.3.3.5 (level 1)
+      - 2.3.3.4 (level 1)
     controls v8:
       - 4.1
       - 4.8


### PR DESCRIPTION
…haring section (2.3.3.X)

Hey guys, noticed a discrepancy in CIS numbers for MacOS 14 (Sonoma) as compared to `CIS Apple macOS 14.0 Sonoma Benchmark v2.1.0` downloaded from https://downloads.cisecurity.org/#/. 

Each rule in the section was off by 1, probably some copy paste from MacOS 13, where there was one more rule `Page 83
Internal Only - General
2.3.3.1 Ensure DVD or CD Sharing Is Disabled (Automated)` that got dropped, but since this was the first rule, after it had been deleted, I assume the numbers of the rules that follow have not been brought down