### PR TITLE
Add missing ODV placeholder in pwpolicy_lower_case_character_enforce

### DIFF
--- a/rules/pwpolicy/pwpolicy_lower_case_character_enforce.yaml
+++ b/rules/pwpolicy/pwpolicy_lower_case_character_enforce.yaml
@@ -27,7 +27,7 @@ fix: |
   <key>policyParameters</key>
   <dict>
   <key>minimumAlphaCharactersLowerCase</key>
-  <integer>1</integer>
+  <integer>$ODV</integer>
   </dict>
   </dict>
   ----


### PR DESCRIPTION
Hello, I've found the issue in `pwpolicy_lower_case_character_enforce.yaml`. The `fix` has missing `$ODV` placeholder and uses always the recommended value `1`.