### PR TITLE
feat: cache resolved os profiles and fix priv logic/scope 

### DIFF
--- a/rules/os/os_safari_prevent_cross-site_tracking_enable.yaml
+++ b/rules/os/os_safari_prevent_cross-site_tracking_enable.yaml
@@ -3,7 +3,12 @@ title: Ensure Prevent Cross-site Tracking in Safari Is Enabled
 discussion: |
   Prevent cross-site tracking _MUST_ be enabled in Safari.
 check: |
-  /usr/bin/profiles -P -o stdout | /usr/bin/grep -cE '"WebKitPreferences.storageBlockingPolicy" = 1|"WebKitStorageBlockingPolicy" = 1|"BlockStoragePolicy" =2' | /usr/bin/awk '{ if ($1 >= 1) {print "1"} else {print "0"}}'
+
+  if [ -n "${CACHED_PROFILES_FILE:-}" ] && [ -f "${CACHED_PROFILES_FILE}" ]; then
+    /usr/bin/grep -qE '"WebKitPreferences.storageBlockingPolicy" = 1|"WebKitStorageBlockingPolicy" = 1|"BlockStoragePolicy" = 2' "${CACHED_PROFILES_FILE}" && echo 1 || echo 0
+  else
+    /usr/bin/sudo /usr/bin/profiles -P -o stdout | /usr/bin/grep -qE '"WebKitPreferences.storageBlockingPolicy" = 1|"WebKitStorageBlockingPolicy" = 1|"BlockStoragePolicy" = 2' && echo 1 || echo 0
+  fi
 result:
   integer: 1
 fix: |

--- a/rules/os/os_safari_show_status_bar_enabled.yaml
+++ b/rules/os/os_safari_show_status_bar_enabled.yaml
@@ -3,7 +3,12 @@ title: "Ensure Show Safari shows the Status Bar is Enabled"
 discussion: |
   Safari _MUST_ be configured to show the status bar.
 check: |
-  /usr/bin/profiles -P -o stdout | /usr/bin/grep -c 'ShowOverlayStatusBar = 1' | /usr/bin/awk '{ if ($1 >= 1) {print "1"} else {print "0"}}'
+
+  if [ -n "${CACHED_PROFILES_FILE:-}" ] && [ -f "${CACHED_PROFILES_FILE}" ]; then
+    /usr/bin/grep -qE 'ShowOverlayStatusBar = 1' "${CACHED_PROFILES_FILE}" && echo 1 || echo 0
+  else
+    /usr/bin/sudo /usr/bin/profiles -P -o stdout | /usr/bin/grep -qE 'ShowOverlayStatusBar = 1' && echo 1 || echo 0
+  fi
 result:
   integer: 1
 fix: |

--- a/rules/os/os_terminal_secure_keyboard_enable.yaml
+++ b/rules/os/os_terminal_secure_keyboard_enable.yaml
@@ -3,12 +3,14 @@ title: Ensure Secure Keyboard Entry Terminal.app is Enabled
 discussion: |
   Secure keyboard entry _MUST_ be enabled in Terminal.app.
 check: |
-  /usr/bin/osascript -l JavaScript << EOS
-  $.NSUserDefaults.alloc.initWithSuiteName('com.apple.Terminal')\
-  .objectForKey('SecureKeyboardEntry').js
-  EOS
+
+  if [ -n "${CACHED_PROFILES_FILE:-}" ] && [ -f "${CACHED_PROFILES_FILE}" ]; then
+    /usr/bin/grep -qE 'SecureKeyboardEntry = 1' "${CACHED_PROFILES_FILE}" && echo 1 || echo 0
+  else
+    /usr/bin/sudo /usr/bin/profiles -P -o stdout | /usr/bin/grep -qE 'SecureKeyboardEntry = 1' && echo 1 || echo 0
+  fi
 result:
-  string: 'true'
+  integer: 1
 fix: |
   This is implemented by a Configuration Profile.
 references:

--- a/rules/system_settings/system_settings_bluetooth_menu_enable.yaml
+++ b/rules/system_settings/system_settings_bluetooth_menu_enable.yaml
@@ -3,10 +3,12 @@ title: Enable Bluetooth Menu
 discussion: |
   The bluetooth menu _MUST_ be enabled.
 check: |
-  /usr/bin/osascript -l JavaScript << EOS
-  $.NSUserDefaults.alloc.initWithSuiteName('com.apple.controlcenter')\
-  .objectForKey('Bluetooth').js
-  EOS
+
+  if [ -n "${CACHED_PROFILES_FILE:-}" ] && [ -f "${CACHED_PROFILES_FILE}" ]; then
+    /usr/bin/grep -qE 'Bluetooth = 18' "${CACHED_PROFILES_FILE}" && echo 18 || echo 0
+  else
+    /usr/bin/sudo /usr/bin/profiles -P -o stdout | /usr/bin/grep -qE 'Bluetooth = 18' && echo 18 || echo 0
+  fi
 result:
   integer: 18
 fix: |

--- a/rules/system_settings/system_settings_diagnostics_reports_disable.yaml
+++ b/rules/system_settings/system_settings_diagnostics_reports_disable.yaml
@@ -5,21 +5,21 @@ discussion: |
 
   The information system _MUST_ be configured to provide only essential capabilities. Disabling the submission of diagnostic and usage information will mitigate the risk of unwanted data being sent to Apple.
 check: |
-  /usr/bin/osascript -l JavaScript << EOS
-  function run() {
-  let pref1 = $.NSUserDefaults.alloc.initWithSuiteName('com.apple.SubmitDiagInfo')\
-  .objectForKey('AutoSubmit').js
-  let pref2 = $.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess')\
-  .objectForKey('allowDiagnosticSubmission').js
-  if ( pref1 == false && pref2 == false ){
-      return("true")
-  } else {
-      return("false")
-  }
-  }
-  EOS
+  if [ -n "${CACHED_PROFILES_FILE:-}" ] && [ -f "${CACHED_PROFILES_FILE}" ]; then
+    if /usr/bin/grep -qE 'AutoSubmit = 0' "${CACHED_PROFILES_FILE}" && /usr/bin/grep -qE 'allowDiagnosticSubmission = 0' "${CACHED_PROFILES_FILE}"; then
+      echo 0
+    else
+      echo 1
+    fi
+  else
+    if /usr/bin/sudo /usr/bin/profiles -P -o stdout | /usr/bin/grep -qE 'AutoSubmit = 0' && /usr/bin/sudo /usr/bin/profiles -P -o stdout | /usr/bin/grep -qE 'allowDiagnosticSubmission = 0'; then
+      echo 0
+    else
+      echo 1
+    fi
+  fi
 result:
-  string: 'true'
+  integer: 0
 fix: |
   This is implemented by a Configuration Profile.
 references:

--- a/rules/system_settings/system_settings_guest_account_disable.yaml
+++ b/rules/system_settings/system_settings_guest_account_disable.yaml
@@ -5,21 +5,21 @@ discussion: |
 
   Turning off guest access prevents anonymous users from accessing files.
 check: |
-  /usr/bin/osascript -l JavaScript << EOS
-  function run() {
-    let pref1 = ObjC.unwrap($.NSUserDefaults.alloc.initWithSuiteName('com.apple.MCX')\
-  .objectForKey('DisableGuestAccount'))
-    let pref2 = ObjC.unwrap($.NSUserDefaults.alloc.initWithSuiteName('com.apple.MCX')\
-  .objectForKey('EnableGuestAccount'))
-    if ( pref1 == true && pref2 == false ) {
-      return("true")
-    } else {
-      return("false")
-    }
-  }
-  EOS
+  if [ -n "${CACHED_PROFILES_FILE:-}" ] && [ -f "${CACHED_PROFILES_FILE}" ]; then
+    if /usr/bin/grep -qE 'DisableGuestAccount = 1' "${CACHED_PROFILES_FILE}" && /usr/bin/grep -qE 'EnableGuestAccount = 0' "${CACHED_PROFILES_FILE}"; then
+      echo 0
+    else
+      echo 1
+    fi
+  else
+    if /usr/bin/sudo /usr/bin/profiles -P -o stdout | /usr/bin/grep -qE 'DisableGuestAccount = 1' && /usr/bin/sudo /usr/bin/profiles -P -o stdout | /usr/bin/grep -qE 'EnableGuestAccount = 0'; then
+      echo 0
+    else
+      echo 1
+    fi
+  fi
 result:
-  string: 'true'
+  integer: 0
 fix: |
   This is implemented by a Configuration Profile.
 references:

--- a/rules/system_settings/system_settings_improve_assistive_voice_disable.yaml
+++ b/rules/system_settings/system_settings_improve_assistive_voice_disable.yaml
@@ -5,12 +5,14 @@ discussion: |
 
   The information system _MUST_ be configured to provide only essential capabilities. Disabling the submission of this information will mitigate the risk of unwanted data being sent to Apple.
 check: |
-  /usr/bin/osascript -l JavaScript << EOS
-  $.NSUserDefaults.alloc.initWithSuiteName('com.apple.Accessibility')\
-  .objectForKey('AXSAudioDonationSiriImprovementEnabled').js
-  EOS
+
+  if [ -n "${CACHED_PROFILES_FILE:-}" ] && [ -f "${CACHED_PROFILES_FILE}" ]; then
+    /usr/bin/grep -qE 'AXSAudioDonationSiriImprovementEnabled = 0' "${CACHED_PROFILES_FILE}" && echo 0 || echo 1
+  else
+    /usr/bin/sudo /usr/bin/profiles -P -o stdout | /usr/bin/grep -qE 'AXSAudioDonationSiriImprovementEnabled = 0' && echo 0 || echo 1
+  fi
 result:
-  string: "false"
+  integer: 0
 fix: |
   This is implemented by a Configuration Profile.
 references:

--- a/rules/system_settings/system_settings_improve_search_disable.yaml
+++ b/rules/system_settings/system_settings_improve_search_disable.yaml
@@ -6,10 +6,12 @@ discussion: |
   The information system _MUST_ be configured to provide only essential capabilities. Disabling the submission of search data will mitigate the risk of unwanted data being sent to Apple.
   
 check: |
-  /usr/bin/osascript -l JavaScript << EOS
-  $.NSUserDefaults.alloc.initWithSuiteName('com.apple.assistant.support')\
-  .objectForKey('Search Queries Data Sharing Status').js
-  EOS
+
+  if [ -n "${CACHED_PROFILES_FILE:-}" ] && [ -f "${CACHED_PROFILES_FILE}" ]; then
+    /usr/bin/grep -qE '"Search Queries Data Sharing Status" = 2' "${CACHED_PROFILES_FILE}" && echo 2 || echo 1
+  else
+    /usr/bin/sudo /usr/bin/profiles -P -o stdout | /usr/bin/grep -qE '"Search Queries Data Sharing Status" = 2' && echo 2 || echo 1
+  fi
 result:
   integer: 2
 fix: |

--- a/rules/system_settings/system_settings_improve_siri_dictation_disable.yaml
+++ b/rules/system_settings/system_settings_improve_siri_dictation_disable.yaml
@@ -5,10 +5,12 @@ discussion: |
 
   The information system _MUST_ be configured to provide only essential capabilities. Disabling the submission of Siri and Dictation information will mitigate the risk of unwanted data being sent to Apple.
 check: |
-  /usr/bin/osascript -l JavaScript << EOS
-  $.NSUserDefaults.alloc.initWithSuiteName('com.apple.assistant.support')\
-  .objectForKey('Siri Data Sharing Opt-In Status').js
-  EOS
+
+  if [ -n "${CACHED_PROFILES_FILE:-}" ] && [ -f "${CACHED_PROFILES_FILE}" ]; then
+    /usr/bin/grep -qE '"Siri Data Sharing Opt-In Status" = 2' "${CACHED_PROFILES_FILE}" && echo 2 || echo 1
+  else
+    /usr/bin/sudo /usr/bin/profiles -P -o stdout | /usr/bin/grep -qE '"Siri Data Sharing Opt-In Status" = 2' && echo 2 || echo 1
+  fi
 result:
   integer: 2
 fix: |

--- a/rules/system_settings/system_settings_internet_sharing_disable.yaml
+++ b/rules/system_settings/system_settings_internet_sharing_disable.yaml
@@ -5,12 +5,14 @@ discussion: |
 
   The information system _MUST_ be configured to provide only essential capabilities. Disabling Internet sharing helps prevent the unauthorized connection of devices, unauthorized transfer of information, and unauthorized tunneling.
 check: |
-  /usr/bin/osascript -l JavaScript << EOS
-  $.NSUserDefaults.alloc.initWithSuiteName('com.apple.MCX')\
-  .objectForKey('forceInternetSharingOff').js
-  EOS
+
+  if [ -n "${CACHED_PROFILES_FILE:-}" ] && [ -f "${CACHED_PROFILES_FILE}" ]; then
+    /usr/bin/grep -qE 'forceInternetSharingOff = 1' "${CACHED_PROFILES_FILE}" && echo 1 || echo 0
+  else
+    /usr/bin/sudo /usr/bin/profiles -P -o stdout | /usr/bin/grep -qE 'forceInternetSharingOff = 1' && echo 1 || echo 0
+  fi
 result:
-  string: 'true'
+  integer: 1
 fix: |
   This is implemented by a Configuration Profile.
 references:

--- a/rules/system_settings/system_settings_personalized_advertising_disable.yaml
+++ b/rules/system_settings/system_settings_personalized_advertising_disable.yaml
@@ -5,12 +5,14 @@ discussion: |
 
   The information system _MUST_ be configured to provide only essential capabilities. Disabling ad tracking ensures that applications and advertisers are unable to track users' interests and deliver targeted advertisements.
 check: |
-  /usr/bin/osascript -l JavaScript << EOS
-  $.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess')\
-  .objectForKey('allowApplePersonalizedAdvertising').js
-  EOS
+
+  if [ -n "${CACHED_PROFILES_FILE:-}" ] && [ -f "${CACHED_PROFILES_FILE}" ]; then
+    /usr/bin/grep -qE 'allowApplePersonalizedAdvertising = 0' "${CACHED_PROFILES_FILE}" && echo 0 || echo 1
+  else
+    /usr/bin/sudo /usr/bin/profiles -P -o stdout | /usr/bin/grep -qE 'allowApplePersonalizedAdvertising = 0' && echo 0 || echo 1
+  fi
 result:
-  string: 'false'
+  integer: 0
 fix: |
   This is implemented by a Configuration Profile.
 references:

--- a/rules/system_settings/system_settings_screensaver_ask_for_password_delay_enforce.yaml
+++ b/rules/system_settings/system_settings_screensaver_ask_for_password_delay_enforce.yaml
@@ -5,17 +5,17 @@ discussion: |
 
   An unattended system with an excessive grace period is vulnerable to a malicious user.
 check: |
-  /usr/bin/osascript -l JavaScript << EOS
-  function run() {
-    let delay = ObjC.unwrap($.NSUserDefaults.alloc.initWithSuiteName('com.apple.screensaver')\
-  .objectForKey('askForPasswordDelay'))
-    if ( delay <= $ODV ) {
-      return("true")
-    } else {
-      return("false")
-    }
-  }
-  EOS
+
+  if [ -n "${CACHED_PROFILES_FILE:-}" ] && [ -f "${CACHED_PROFILES_FILE}" ]; then
+    delay=$(/usr/bin/grep -oE 'askForPasswordDelay = [0-9]+' "${CACHED_PROFILES_FILE}" | /usr/bin/awk '{print $3}' || echo "999")
+  else
+    delay=$(/usr/bin/sudo /usr/bin/profiles -P -o stdout | /usr/bin/grep -oE 'askForPasswordDelay = [0-9]+' | /usr/bin/awk '{print $3}' || echo "999")
+  fi
+  if [ "$delay" -le $ODV ]; then
+    echo "true"
+  else
+    echo "false"
+  fi
 result:
   string: 'true'
 fix: |

--- a/rules/system_settings/system_settings_time_server_configure.yaml
+++ b/rules/system_settings/system_settings_time_server_configure.yaml
@@ -5,10 +5,12 @@ discussion: |
 
   This rule ensures the uniformity of time stamps for information systems with multiple system clocks and systems connected over a network.
 check: |
-  /usr/bin/osascript -l JavaScript << EOS
-  $.NSUserDefaults.alloc.initWithSuiteName('com.apple.MCX')\
-  .objectForKey('timeServer').js
-  EOS
+
+  if [ -n "${CACHED_PROFILES_FILE:-}" ] && [ -f "${CACHED_PROFILES_FILE}" ]; then
+    /usr/bin/grep -oE 'timeServer = "[^"]*"' "${CACHED_PROFILES_FILE}" | /usr/bin/sed 's/timeServer = "//; s/"//' | /usr/bin/head -1
+  else
+    /usr/bin/sudo /usr/bin/profiles -P -o stdout | /usr/bin/grep -oE 'timeServer = "[^"]*"' | /usr/bin/sed 's/timeServer = "//; s/"//' | /usr/bin/head -1
+  fi
 result:
   string: $ODV
 fix: |

--- a/rules/system_settings/system_settings_wifi_menu_enable.yaml
+++ b/rules/system_settings/system_settings_wifi_menu_enable.yaml
@@ -3,10 +3,12 @@ title: Enable Wifi Menu
 discussion: |
   The WiFi menu _MUST_ be enabled.
 check: |
-  /usr/bin/osascript -l JavaScript << EOS
-  $.NSUserDefaults.alloc.initWithSuiteName('com.apple.controlcenter')\
-  .objectForKey('WiFi').js
-  EOS
+
+  if [ -n "${CACHED_PROFILES_FILE:-}" ] && [ -f "${CACHED_PROFILES_FILE}" ]; then
+    /usr/bin/grep -A20 'com.apple.controlcenter' "${CACHED_PROFILES_FILE}" | /usr/bin/grep -oE 'WiFi = [0-9]+' | /usr/bin/awk '{print $3}' || echo 0
+  else
+    /usr/bin/sudo /usr/bin/profiles -P -o stdout | /usr/bin/grep -A20 'com.apple.controlcenter' | /usr/bin/grep -oE 'WiFi = [0-9]+' | /usr/bin/awk '{print $3}' || echo 0
+  fi
 result:
   integer: 18
 fix: |


### PR DESCRIPTION
  Summary
  Resolve sudo privilege mismatches by introducing unified profile caching with backwards compatibility, preferring
  consistent MDM-profile based checks over defaults-based approaches in rules.

  Motivation
  - Eliminates privilege escalation inconsistencies through unified caching approach
  - Ensures compliance checks accurately reflect security policy requirements
  - Improves MDM compatibility across all systems by using the authoritative profile data (open to feedback on why
  sys setting may need OSA script though)
  - Makes rule expectations clearer with profile configured vals on result expectation vs boolean flags where
  possible
  - Thinking `profiles -P` shows the effective/resolved configuration that macOS is actually enforcing