### PR TITLE
Update pwpolicy_history_enforce.yaml

### DIFF
--- a/rules/pwpolicy/pwpolicy_history_enforce.yaml
+++ b/rules/pwpolicy/pwpolicy_history_enforce.yaml
@@ -30,8 +30,6 @@ references:
       - SRG-OS-000077-GPOS-00045
       - SRG-OS-000775-GPOS-00230
     disa_stig:
-      macos_14:
-        - APPL-14-003009
       macos_13:
         - APPL-13-003009
       ios_18:
@@ -64,14 +62,10 @@ platforms:
       benchmarks:
         - name: cis_lvl1
         - name: cis_lvl2
-        - name: disa_stig
-          severity: medium
     '14.0':
       benchmarks:
         - name: cis_lvl1
         - name: cis_lvl2
-        - name: disa_stig
-          severity: medium
     '13.0':
       benchmarks:
         - name: cis_lvl1


### PR DESCRIPTION
From my research it looks like this was last seen in DISA STIG for MacOS 13 (Ventura), i cant locate it for MacOS 14 (Sonoma)/15 (Sequoia).