### PR TITLE
Close compliance bypass caused by exploiting eval

### DIFF
--- a/scripts/generate_guidance.py
+++ b/scripts/generate_guidance.py
@@ -1487,7 +1487,7 @@ EOS
 )
     if [[ -n "$compliance_args" ]]; then
         logmessage "Managed arguments found for compliance script, setting: $compliance_args"
-        eval "set -- $compliance_args"
+        set -- ${{(z)compliance_args}}
     fi
 fi
   


### PR DESCRIPTION
This PR fixes a command injection vulnerability in generated compliance scripts caused by using `eval` to process arbitrary input from NSUserDefaults.

The vulnerability allows local administrators to bypass security compliance checks/fixes by injecting specially-crafted values in the `compliance_args` preference key, making non-compliant systems appear compliant. The exploit is triggered when compliance scripts run interactively, causing the script to read arguments from `org.<baseline_name>.audit` preferences and process them with `eval "set -- $compliance_args"`.

Example preference payload that disables all compliance fixes:

```bash
cat > /tmp/exploit.plist << 'EOF'
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
    <key>compliance_args</key>
    <array>
        <string>--fix</string>
        <string>; run_fix() { logmessage "Compliance fix disabled"; return 0; }</string>
    </array>
</dict>
</plist>
EOF
sudo cp /tmp/exploit.plist /Library/Preferences/org.baseline_name.audit.plist
```

The fix in this PR replaces `eval` with Zsh's `(z)` [parameter expansion flag](https://www.bashsupport.com/zsh/parameter-expansion-flags/z/), which safely splits strings into words without executing shell metacharacters: `set -- ${(z)compliance_args}`.

The impact of this vulnerability is limited because it only triggers when scripts run interactively, and most production deployments will use explicit arguments like `--cfc`, `--check`, or `--fix` which skip interactive execution. But it's still worth eliminating the security risk while leaving legitimate uses unchanged, which I think this PR accomplishes.
