### PR TITLE
Update document title to 26.0 for Tahoe guidance output

### DIFF
--- a/templates/adoc_additional_docs.adoc
+++ b/templates/adoc_additional_docs.adoc
@@ -64,5 +64,5 @@ ASSOCIATED DOCUMENTS
 |===
 |Document Number or Descriptor
 |Document Title
-|link:https://www.cisecurity.org/benchmark/apple_os/[Apple macOS 15.0]|_CIS Apple macOS 15.0 Benchmark version 1.1.0_
+|link:https://www.cisecurity.org/benchmark/apple_os/[Apple macOS 26.0]|_CIS Apple macOS 26.0 Benchmark version 1.0_
 |===


### PR DESCRIPTION
This PR updates the macOS version and benchmark version to align with macOS Tahoe releases.