### PR TITLE
Extend os_on_device_dictation_enforce discussion

### DIFF
--- a/rules/os/os_on_device_dictation_enforce.yaml
+++ b/rules/os/os_on_device_dictation_enforce.yaml
@@ -4,6 +4,8 @@ discussion: |
   Dictation _MUST_ be restricted to on device only to prevent potential data exfiltration.
 
   The information system _MUST_ be configured to provide only essential capabilities.
+  
+  IMPORTANT: Device dictation enforcing is not supported on Intel devices. This rule is only applicable to Apple Silicon devices.
 check: |
   /usr/bin/osascript -l JavaScript << EOS
   $.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess')\


### PR DESCRIPTION
When applying rule `os_on_device_dictation_enforce` on device with Intel architecture, following warning was found in a console 
```
os_on_device_dictation_enforce does not apply to this architecture
```

`forceOnDeviceOnlyDictation` key is behind a feature introduced on Apple Silicon Macs (M1+).