### PR TITLE
Find and replace all lines in SSHD config instead of append-only

### DIFF
--- a/rules/os/os_sshd_channel_timeout_configure.yaml
+++ b/rules/os/os_sshd_channel_timeout_configure.yaml
@@ -24,7 +24,7 @@ fix: |
   ssh_config=("ChannelTimeout $ODV")
   ssh_setting=$(echo $ssh_config | /usr/bin/cut -d " " -f1)
 
-  /usr/bin/grep -qEi "^$ssh_setting" "${include_dir}01-mscp-ssh.conf" && /usr/bin/sed -i "" "s/^$ssh_setting.*/${ssh_config}/" "${include_dir}01-mscp-ssh.conf" || echo "$ssh_config" >> "${include_dir}01-mscp-ssh.conf"
+  /usr/bin/grep -qEi "^$ssh_setting" "${include_dir}01-mscp-sshd.conf" && /usr/bin/sed -i "" "s/^$ssh_setting.*/${ssh_config}/" "${include_dir}01-mscp-sshd.conf" || echo "$ssh_config" >> "${include_dir}01-mscp-sshd.conf"
 
   for file in $(ls ${include_dir}); do
     if [[ "$file" == "100-macos.conf" ]]; then

--- a/rules/os/os_sshd_channel_timeout_configure.yaml
+++ b/rules/os/os_sshd_channel_timeout_configure.yaml
@@ -21,22 +21,10 @@ fix: |
     /usr/bin/sed -i.bk "1s/.*/Include \/etc\/ssh\/sshd_config.d\/\*/" /etc/ssh/sshd_config
   fi
 
-  if /usr/bin/grep -qF 'channeltimeout' "${include_dir}01-mscp-sshd.conf" 2>/dev/null
-  then
-    temp_config=$(/usr/bin/mktemp)
-    /bin/chmod 644 "${temp_config}"
-    
-    /usr/bin/awk -v ODV="$ODV" '
-        /^channeltimeout [0-9]+$/ {
-            $0 = "channeltimeout " ODV
-        }
-        1
-    ' "${include_dir}01-mscp-sshd.conf" > "${temp_config}"
-    
-    /bin/mv -f "${temp_config}" "${include_dir}01-mscp-sshd.conf"
-  else
-    echo "channeltimeout $ODV" >> "${include_dir}01-mscp-sshd.conf"
-  fi
+  ssh_config=("ChannelTimeout $ODV")
+  ssh_setting=$(echo $ssh_config | /usr/bin/cut -d " " -f1)
+
+  /usr/bin/grep -qEi "^$ssh_setting" "${include_dir}01-mscp-ssh.conf" && /usr/bin/sed -i "" "s/^$ssh_setting.*/${ssh_config}/" "${include_dir}01-mscp-ssh.conf" || echo "$ssh_config" >> "${include_dir}01-mscp-ssh.conf"
 
   for file in $(ls ${include_dir}); do
     if [[ "$file" == "100-macos.conf" ]]; then

--- a/rules/os/os_sshd_channel_timeout_configure.yaml
+++ b/rules/os/os_sshd_channel_timeout_configure.yaml
@@ -21,7 +21,22 @@ fix: |
     /usr/bin/sed -i.bk "1s/.*/Include \/etc\/ssh\/sshd_config.d\/\*/" /etc/ssh/sshd_config
   fi
 
-  /usr/bin/grep -qxF 'channeltimeout $ODV' "${include_dir}01-mscp-sshd.conf" 2>/dev/null || echo "channeltimeout $ODV" >> "${include_dir}01-mscp-sshd.conf"
+  if /usr/bin/grep -qF 'channeltimeout' "${include_dir}01-mscp-sshd.conf" 2>/dev/null
+  then
+    temp_config=$(/usr/bin/mktemp)
+    /bin/chmod 644 "${temp_config}"
+    
+    /usr/bin/awk -v ODV="$ODV" '
+        /^channeltimeout [0-9]+$/ {
+            $0 = "channeltimeout " ODV
+        }
+        1
+    ' "${include_dir}01-mscp-sshd.conf" > "${temp_config}"
+    
+    /bin/mv -f "${temp_config}" "${include_dir}01-mscp-sshd.conf"
+  else
+    echo "channeltimeout $ODV" >> "${include_dir}01-mscp-sshd.conf"
+  fi
 
   for file in $(ls ${include_dir}); do
     if [[ "$file" == "100-macos.conf" ]]; then

--- a/rules/os/os_sshd_client_alive_count_max_configure.yaml
+++ b/rules/os/os_sshd_client_alive_count_max_configure.yaml
@@ -21,22 +21,10 @@ fix: |
     /usr/bin/sed -i.bk "1s/.*/Include \/etc\/ssh\/sshd_config.d\/\*/" /etc/ssh/sshd_config
   fi
 
-  if /usr/bin/grep -qF 'clientalivecountmax' "${include_dir}01-mscp-sshd.conf" 2>/dev/null
-  then
-    temp_config=$(/usr/bin/mktemp)
-    /bin/chmod 644 "${temp_config}"
-    
-    /usr/bin/awk -v ODV="$ODV" '
-        /^clientalivecountmax [0-9]+$/ {
-            $0 = "clientalivecountmax " ODV
-        }
-        1
-    ' "${include_dir}01-mscp-sshd.conf" > "${temp_config}"
-    
-    /bin/mv -f "${temp_config}" "${include_dir}01-mscp-sshd.conf"
-  else
-    echo "clientalivecountmax $ODV" >> "${include_dir}01-mscp-sshd.conf"
-  fi
+  ssh_config=("ClientAliveCountMax $ODV")
+  ssh_setting=$(echo $ssh_config | /usr/bin/cut -d " " -f1)
+
+  /usr/bin/grep -qEi "^$ssh_setting" "${include_dir}01-mscp-ssh.conf" && /usr/bin/sed -i "" "s/^$ssh_setting.*/${ssh_config}/" "${include_dir}01-mscp-ssh.conf" || echo "$ssh_config" >> "${include_dir}01-mscp-ssh.conf"
   
   for file in $(ls ${include_dir}); do
     if [[ "$file" == "100-macos.conf" ]]; then

--- a/rules/os/os_sshd_client_alive_count_max_configure.yaml
+++ b/rules/os/os_sshd_client_alive_count_max_configure.yaml
@@ -24,7 +24,7 @@ fix: |
   ssh_config=("ClientAliveCountMax $ODV")
   ssh_setting=$(echo $ssh_config | /usr/bin/cut -d " " -f1)
 
-  /usr/bin/grep -qEi "^$ssh_setting" "${include_dir}01-mscp-ssh.conf" && /usr/bin/sed -i "" "s/^$ssh_setting.*/${ssh_config}/" "${include_dir}01-mscp-ssh.conf" || echo "$ssh_config" >> "${include_dir}01-mscp-ssh.conf"
+  /usr/bin/grep -qEi "^$ssh_setting" "${include_dir}01-mscp-sshd.conf" && /usr/bin/sed -i "" "s/^$ssh_setting.*/${ssh_config}/" "${include_dir}01-mscp-sshd.conf" || echo "$ssh_config" >> "${include_dir}01-mscp-sshd.conf"
   
   for file in $(ls ${include_dir}); do
     if [[ "$file" == "100-macos.conf" ]]; then

--- a/rules/os/os_sshd_client_alive_count_max_configure.yaml
+++ b/rules/os/os_sshd_client_alive_count_max_configure.yaml
@@ -20,18 +20,23 @@ fix: |
   if [[ -z $include_dir ]]; then
     /usr/bin/sed -i.bk "1s/.*/Include \/etc\/ssh\/sshd_config.d\/\*/" /etc/ssh/sshd_config
   fi
-  
-  temp_config=$(/usr/bin/mktemp)
-  /bin/chmod 644 "${temp_config}"
-  
-  /usr/bin/awk -v ODV="$ODV" '
-      /^clientalivecountmax [0-9]+$/ {
-          $0 = "clientalivecountmax " ODV
-      }
-      1
-  ' "${include_dir}01-mscp-sshd.conf" > "${temp_config}"
-  
-  /bin/mv -f "${temp_config}" "${include_dir}01-mscp-sshd.conf"
+
+  if /usr/bin/grep -qF 'clientalivecountmax' "${include_dir}01-mscp-sshd.conf" 2>/dev/null
+  then
+    temp_config=$(/usr/bin/mktemp)
+    /bin/chmod 644 "${temp_config}"
+    
+    /usr/bin/awk -v ODV="$ODV" '
+        /^clientalivecountmax [0-9]+$/ {
+            $0 = "clientalivecountmax " ODV
+        }
+        1
+    ' "${include_dir}01-mscp-sshd.conf" > "${temp_config}"
+    
+    /bin/mv -f "${temp_config}" "${include_dir}01-mscp-sshd.conf"
+  else
+    echo "clientalivecountmax $ODV" >> "${include_dir}01-mscp-sshd.conf"
+  fi
   
   for file in $(ls ${include_dir}); do
     if [[ "$file" == "100-macos.conf" ]]; then

--- a/rules/os/os_sshd_client_alive_count_max_configure.yaml
+++ b/rules/os/os_sshd_client_alive_count_max_configure.yaml
@@ -16,13 +16,23 @@ fix: |
   [source,bash]
   ----
   include_dir=$(/usr/bin/awk '/^Include/ {print $2}' /etc/ssh/sshd_config | /usr/bin/tr -d '*')
-
+  
   if [[ -z $include_dir ]]; then
     /usr/bin/sed -i.bk "1s/.*/Include \/etc\/ssh\/sshd_config.d\/\*/" /etc/ssh/sshd_config
   fi
-
-  /usr/bin/grep -qxF 'clientalivecountmax $ODV' "${include_dir}01-mscp-sshd.conf" 2>/dev/null || echo "clientalivecountmax $ODV" >> "${include_dir}01-mscp-sshd.conf"
-
+  
+  temp_config=$(/usr/bin/mktemp)
+  /bin/chmod 644 "${temp_config}"
+  
+  /usr/bin/awk -v ODV="$ODV" '
+      /^clientalivecountmax [0-9]+$/ {
+          $0 = "clientalivecountmax " ODV
+      }
+      1
+  ' "${include_dir}01-mscp-sshd.conf" > "${temp_config}"
+  
+  /bin/mv -f "${temp_config}" "${include_dir}01-mscp-sshd.conf"
+  
   for file in $(ls ${include_dir}); do
     if [[ "$file" == "100-macos.conf" ]]; then
         continue

--- a/rules/os/os_sshd_client_alive_interval_configure.yaml
+++ b/rules/os/os_sshd_client_alive_interval_configure.yaml
@@ -23,7 +23,22 @@ fix: |
     /usr/bin/sed -i.bk "1s/.*/Include \/etc\/ssh\/sshd_config.d\/\*/" /etc/ssh/sshd_config
   fi
 
-  /usr/bin/grep -qxF 'clientaliveinterval $ODV' "${include_dir}01-mscp-sshd.conf" 2>/dev/null || echo "clientaliveinterval $ODV" >> "${include_dir}01-mscp-sshd.conf"
+  if /usr/bin/grep -qF 'clientaliveinterval' "${include_dir}01-mscp-sshd.conf" 2>/dev/null
+  then
+    temp_config=$(/usr/bin/mktemp)
+    /bin/chmod 644 "${temp_config}"
+    
+    /usr/bin/awk -v ODV="$ODV" '
+        /^clientaliveinterval [0-9]+$/ {
+            $0 = "clientaliveinterval " ODV
+        }
+        1
+    ' "${include_dir}01-mscp-sshd.conf" > "${temp_config}"
+    
+    /bin/mv -f "${temp_config}" "${include_dir}01-mscp-sshd.conf"
+  else
+    echo "clientaliveinterval $ODV" >> "${include_dir}01-mscp-sshd.conf"
+  fi
 
   for file in $(ls ${include_dir}); do
     if [[ "$file" == "100-macos.conf" ]]; then

--- a/rules/os/os_sshd_client_alive_interval_configure.yaml
+++ b/rules/os/os_sshd_client_alive_interval_configure.yaml
@@ -26,7 +26,7 @@ fix: |
   ssh_config=("ClientAliveInterval $ODV")
   ssh_setting=$(echo $ssh_config | /usr/bin/cut -d " " -f1)
 
-  /usr/bin/grep -qEi "^$ssh_setting" "${include_dir}01-mscp-ssh.conf" && /usr/bin/sed -i "" "s/^$ssh_setting.*/${ssh_config}/" "${include_dir}01-mscp-ssh.conf" || echo "$ssh_config" >> "${include_dir}01-mscp-ssh.conf"
+  /usr/bin/grep -qEi "^$ssh_setting" "${include_dir}01-mscp-sshd.conf" && /usr/bin/sed -i "" "s/^$ssh_setting.*/${ssh_config}/" "${include_dir}01-mscp-sshd.conf" || echo "$ssh_config" >> "${include_dir}01-mscp-sshd.conf"
 
   for file in $(ls ${include_dir}); do
     if [[ "$file" == "100-macos.conf" ]]; then

--- a/rules/os/os_sshd_client_alive_interval_configure.yaml
+++ b/rules/os/os_sshd_client_alive_interval_configure.yaml
@@ -23,22 +23,10 @@ fix: |
     /usr/bin/sed -i.bk "1s/.*/Include \/etc\/ssh\/sshd_config.d\/\*/" /etc/ssh/sshd_config
   fi
 
-  if /usr/bin/grep -qF 'clientaliveinterval' "${include_dir}01-mscp-sshd.conf" 2>/dev/null
-  then
-    temp_config=$(/usr/bin/mktemp)
-    /bin/chmod 644 "${temp_config}"
-    
-    /usr/bin/awk -v ODV="$ODV" '
-        /^clientaliveinterval [0-9]+$/ {
-            $0 = "clientaliveinterval " ODV
-        }
-        1
-    ' "${include_dir}01-mscp-sshd.conf" > "${temp_config}"
-    
-    /bin/mv -f "${temp_config}" "${include_dir}01-mscp-sshd.conf"
-  else
-    echo "clientaliveinterval $ODV" >> "${include_dir}01-mscp-sshd.conf"
-  fi
+  ssh_config=("ClientAliveInterval $ODV")
+  ssh_setting=$(echo $ssh_config | /usr/bin/cut -d " " -f1)
+
+  /usr/bin/grep -qEi "^$ssh_setting" "${include_dir}01-mscp-ssh.conf" && /usr/bin/sed -i "" "s/^$ssh_setting.*/${ssh_config}/" "${include_dir}01-mscp-ssh.conf" || echo "$ssh_config" >> "${include_dir}01-mscp-ssh.conf"
 
   for file in $(ls ${include_dir}); do
     if [[ "$file" == "100-macos.conf" ]]; then


### PR DESCRIPTION
I copied over the grep -qEi && sed || echo > pattern from the other SSH rules into the SSHD rules.

This fixes an issue I had in testing where the previous configuration was not overwritten, a new line was simply added to the file and SSHD did not adopt the change.