### PR TITLE
Remove unnecessary run functions

### DIFF
--- a/rules/os/os_calendar_app_disable.yaml
+++ b/rules/os/os_calendar_app_disable.yaml
@@ -14,21 +14,19 @@ discussion: |
   ====
 check: |
   /usr/bin/osascript -l JavaScript << EOS
-  function run() {
-    let pref1 = ObjC.unwrap($.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess.new')\
-    .objectForKey('familyControlsEnabled'))
-    let pathlist = $.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess.new')\
-    .objectForKey('pathBlackList').js
-    for ( let app in pathlist ) {
-        if ( ObjC.unwrap(pathlist[app]) == "/Applications/Calendar.app" && pref1 == true ){
-            return("true")
-        }
-    }
-    return("false")
-    }
+  let pref1 = ObjC.unwrap($.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess.new')\
+  .objectForKey('familyControlsEnabled'))
+  let pathlist = $.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess.new')\
+  .objectForKey('pathBlackList').js
+  for ( let app in pathlist ) {
+      if ( ObjC.unwrap(pathlist[app]) == "/Applications/Calendar.app" && pref1 == true ){
+          "true"
+      }
+  }
+  "false"
   EOS
 result:
-  string: 'true'
+  string: "true"
 fix: |
   This is implemented by a Configuration Profile.
 references:
@@ -62,7 +60,7 @@ references:
     - CM.L2-3.4.6
     - CM.L2-3.4.7
 macOS:
-  - '26.0'
+  - "26.0"
 tags:
   - cnssi-1253_low
   - cnssi-1253_high

--- a/rules/os/os_facetime_app_disable.yaml
+++ b/rules/os/os_facetime_app_disable.yaml
@@ -11,21 +11,19 @@ discussion: |
   ====
 check: |
   /usr/bin/osascript -l JavaScript << EOS
-  function run() {
-    let pref1 = ObjC.unwrap($.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess.new')\
-    .objectForKey('familyControlsEnabled'))
-    let pathlist = $.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess.new')\
-    .objectForKey('pathBlackList').js
-    for ( let app in pathlist ) {
-        if ( ObjC.unwrap(pathlist[app]) == "/Applications/FaceTime.app" && pref1 == true ){
-            return("true")
-        }
-    }
-    return("false")
-    }
+  let pref1 = ObjC.unwrap($.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess.new')\
+  .objectForKey('familyControlsEnabled'))
+  let pathlist = $.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess.new')\
+  .objectForKey('pathBlackList').js
+  for ( let app in pathlist ) {
+      if ( ObjC.unwrap(pathlist[app]) == "/Applications/FaceTime.app" && pref1 == true ){
+          "true"
+      }
+  }
+  "false"
   EOS
 result:
-  string: 'true'
+  string: "true"
 fix: |
   This is implemented by a Configuration Profile.
 references:
@@ -59,7 +57,7 @@ references:
     - CM.L2-3.4.6
     - CM.L2-3.4.7
 macOS:
-  - '26.0'
+  - "26.0"
 tags:
   - cnssi-1253_low
   - cnssi-1253_high

--- a/rules/os/os_mail_app_disable.yaml
+++ b/rules/os/os_mail_app_disable.yaml
@@ -16,21 +16,19 @@ discussion: |
   ====
 check: |
   /usr/bin/osascript -l JavaScript << EOS
-  function run() {
-    let pref1 = ObjC.unwrap($.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess.new')\
-    .objectForKey('familyControlsEnabled'))
-    let pathlist = $.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess.new')\
-    .objectForKey('pathBlackList').js
-    for ( let app in pathlist ) {
-        if ( ObjC.unwrap(pathlist[app]) == "/Applications/Mail.app" && pref1 == true ){
-            return("true")
-        }
-    }
-    return("false")
-    }
+  let pref1 = ObjC.unwrap($.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess.new')\
+  .objectForKey('familyControlsEnabled'))
+  let pathlist = $.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess.new')\
+  .objectForKey('pathBlackList').js
+  for ( let app in pathlist ) {
+      if ( ObjC.unwrap(pathlist[app]) == "/Applications/Mail.app" && pref1 == true ){
+          "true"
+      }
+  }
+  "false"
   EOS
 result:
-  string: 'true'
+  string: "true"
 fix: |
   This is implemented by a Configuration Profile.
 references:
@@ -64,7 +62,7 @@ references:
     - CM.L2-3.4.6
     - CM.L2-3.4.7
 macOS:
-  - '26.0'
+  - "26.0"
 tags:
   - cnssi-1253_low
   - cnssi-1253_high

--- a/rules/os/os_messages_app_disable.yaml
+++ b/rules/os/os_messages_app_disable.yaml
@@ -11,21 +11,19 @@ discussion: |
   ====
 check: |
   /usr/bin/osascript -l JavaScript << EOS
-  function run() {
-    let pref1 = ObjC.unwrap($.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess.new')\
-    .objectForKey('familyControlsEnabled'))
-    let pathlist = $.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess.new')\
-    .objectForKey('pathBlackList').js
-    for ( let app in pathlist ) {
-        if ( ObjC.unwrap(pathlist[app]) == "/Applications/Messages.app" && pref1 == true ){
-            return("true")
-        }
-    }
-    return("false")
-    }
+  let pref1 = ObjC.unwrap($.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess.new')\
+  .objectForKey('familyControlsEnabled'))
+  let pathlist = $.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess.new')\
+  .objectForKey('pathBlackList').js
+  for ( let app in pathlist ) {
+      if ( ObjC.unwrap(pathlist[app]) == "/Applications/Messages.app" && pref1 == true ){
+          "true"
+      }
+  }
+  "false"
   EOS
 result:
-  string: 'true'
+  string: "true"
 fix: |
   This is implemented by a Configuration Profile.
 references:
@@ -59,7 +57,7 @@ references:
     - CM.L2-3.4.6
     - CM.L2-3.4.7
 macOS:
-  - '26.0'
+  - "26.0"
 tags:
   - cnssi-1253_low
   - cnssi-1253_high

--- a/rules/os/os_screensaver_timeout_loginwindow_enforce.yaml
+++ b/rules/os/os_screensaver_timeout_loginwindow_enforce.yaml
@@ -6,18 +6,16 @@ discussion: |
   This rule ensures that a full session lock is triggered within no more than $ODV seconds of inactivity.
 check: |
   /usr/bin/osascript -l JavaScript << EOS
-  function run() {
-    let timeout = ObjC.unwrap($.NSUserDefaults.alloc.initWithSuiteName('com.apple.screensaver')\
+  let timeout = ObjC.unwrap($.NSUserDefaults.alloc.initWithSuiteName('com.apple.screensaver')\
   .objectForKey('loginWindowIdleTime'))
-    if ( timeout <= $ODV ) {
-      return("true")
-    } else {
-      return("false")
-    }
+  if ( timeout <= $ODV ) {
+      "true"
+  } else {
+      "false"
   }
   EOS
 result:
-  string: 'true'
+  string: "true"
 fix: |
   This is implemented by a Configuration Profile.
 references:
@@ -39,7 +37,7 @@ references:
     controls v8:
       - 4.3
 macOS:
-  - '26.0'
+  - "26.0"
 odv:
   hint: Number of seconds.
   recommended: 1200

--- a/rules/os/os_software_update_deferral.yaml
+++ b/rules/os/os_software_update_deferral.yaml
@@ -4,18 +4,16 @@ discussion: |
   Software updates _MUST_ be deferred for $ODV days or less.
 check: |
   /usr/bin/osascript -l JavaScript << EOS
-  function run() {
-    let timeout = ObjC.unwrap($.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess')\
+  let timeout = ObjC.unwrap($.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess')\
   .objectForKey('enforcedSoftwareUpdateDelay')) || 0
-    if ( timeout <= $ODV ) {
-      return("true")
-    } else {
-      return("false")
-    }
+  if ( timeout <= $ODV ) {
+      "true"
+  } else {
+      "false"
   }
   EOS
 result:
-  string: 'true'
+  string: "true"
 fix: |
   This is implemented by a Configuration Profile.
 references:
@@ -40,7 +38,7 @@ references:
       - 7.3
       - 7.4
 macOS:
-  - '26.0'
+  - "26.0"
 odv:
   hint: Number of days.
   recommended: 30

--- a/rules/os/os_user_app_installation_prohibit.yaml
+++ b/rules/os/os_user_app_installation_prohibit.yaml
@@ -11,21 +11,19 @@ discussion: |
   ====
 check: |
   /usr/bin/osascript -l JavaScript << EOS
-  function run() {
-    let pref1 = ObjC.unwrap($.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess.new')\
-    .objectForKey('familyControlsEnabled'))
-    let pathlist = $.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess.new')\
-    .objectForKey('pathBlackList').js
-    for ( let app in pathlist ) {
-        if ( ObjC.unwrap(pathlist[app]) == "/Users/" && pref1 == true ){
-            return("true")
-        }
-    }
-    return("false")
-    }
+  let pref1 = ObjC.unwrap($.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess.new')\
+  .objectForKey('familyControlsEnabled'))
+  let pathlist = $.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess.new')\
+  .objectForKey('pathBlackList').js
+  for ( let app in pathlist ) {
+      if ( ObjC.unwrap(pathlist[app]) == "/Users/" && pref1 == true ){
+          "true"
+      }
+  }
+  "false"
   EOS
 result:
-  string: 'true'
+  string: "true"
 fix: |
   This is implemented by a Configuration Profile.
 references:
@@ -45,7 +43,7 @@ references:
   cmmc:
     - CM.L2-3.4.9
 macOS:
-  - '26.0'
+  - "26.0"
 tags:
   - cnssi-1253_low
   - cnssi-1253_high

--- a/rules/system_settings/system_settings_diagnostics_reports_disable.yaml
+++ b/rules/system_settings/system_settings_diagnostics_reports_disable.yaml
@@ -6,20 +6,18 @@ discussion: |
   The information system _MUST_ be configured to provide only essential capabilities. Disabling the submission of diagnostic and usage information will mitigate the risk of unwanted data being sent to Apple.
 check: |
   /usr/bin/osascript -l JavaScript << EOS
-  function run() {
   let pref1 = $.NSUserDefaults.alloc.initWithSuiteName('com.apple.SubmitDiagInfo')\
   .objectForKey('AutoSubmit').js
   let pref2 = $.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess')\
   .objectForKey('allowDiagnosticSubmission').js
   if ( pref1 == false && pref2 == false ){
-      return("true")
+      "true"
   } else {
-      return("false")
-  }
+      "false"
   }
   EOS
 result:
-  string: 'true'
+  string: "true"
 fix: |
   This is implemented by a Configuration Profile.
 references:
@@ -52,7 +50,7 @@ references:
   cmmc:
     - AC.L1-3.1.20
 macOS:
-  - '26.0'
+  - "26.0"
 tags:
   - 800-53r5_low
   - 800-53r4_low

--- a/rules/system_settings/system_settings_find_my_disable.yaml
+++ b/rules/system_settings/system_settings_find_my_disable.yaml
@@ -8,22 +8,20 @@ discussion: |
   Apple's Find My service uses a personal AppleID for authentication. Organizations should rely on MDM solutions, which have much more secure authentication requirements, to perform remote lock and remote wipe.
 check: |
   /usr/bin/osascript -l JavaScript << EOS
-  function run() {
-    let pref1 = ObjC.unwrap($.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess')\
+  let pref1 = ObjC.unwrap($.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess')\
   .objectForKey('allowFindMyDevice'))
-    let pref2 = ObjC.unwrap($.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess')\
+  let pref2 = ObjC.unwrap($.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess')\
   .objectForKey('allowFindMyFriends'))
-    let pref3 = ObjC.unwrap($.NSUserDefaults.alloc.initWithSuiteName('com.apple.icloud.managed')\
+  let pref3 = ObjC.unwrap($.NSUserDefaults.alloc.initWithSuiteName('com.apple.icloud.managed')\
   .objectForKey('DisableFMMiCloudSetting'))
-    if ( pref1 == false && pref2 == false && pref3 == true ) {
-      return("true")
-    } else {
-      return("false")
-    }
+  if ( pref1 == false && pref2 == false && pref3 == true ) {
+      "true"
+  } else {
+      "false"
   }
   EOS
 result:
-  string: 'true'
+  string: "true"
 fix: |
   This is implemented by a Configuration Profile.
 references:
@@ -58,7 +56,7 @@ references:
     - CM.L2-3.4.6
     - CM.L2-3.4.7
 macOS:
-  - '26.0'
+  - "26.0"
 tags:
   - 800-53r5_low
   - 800-53r5_moderate

--- a/rules/system_settings/system_settings_gatekeeper_identified_developers_allowed.yaml
+++ b/rules/system_settings/system_settings_gatekeeper_identified_developers_allowed.yaml
@@ -6,20 +6,18 @@ discussion: |
   Gatekeeper settings must be configured correctly to only allow the system to run applications downloaded from the Mac App Store or applications signed with a valid Apple Developer ID code. Administrator users will still have the option to override these settings on a per-app basis. Gatekeeper is a security feature that ensures that applications must be digitally signed by an Apple-issued certificate in order to run. Digital signatures allow the macOS to verify that the application has not been modified by a malicious third party.
 check: |
   /usr/bin/osascript -l JavaScript << EOS
-  function run() {
-    let pref1 = ObjC.unwrap($.NSUserDefaults.alloc.initWithSuiteName('com.apple.systempolicy.control')\
+  let pref1 = ObjC.unwrap($.NSUserDefaults.alloc.initWithSuiteName('com.apple.systempolicy.control')\
   .objectForKey('AllowIdentifiedDevelopers'))
-    let pref2 = ObjC.unwrap($.NSUserDefaults.alloc.initWithSuiteName('com.apple.systempolicy.control')\
+  let pref2 = ObjC.unwrap($.NSUserDefaults.alloc.initWithSuiteName('com.apple.systempolicy.control')\
   .objectForKey('EnableAssessment'))
-    if ( pref1 == true && pref2 == true ) {
-      return("true")
-    } else {
-      return("false")
-    }
+  if ( pref1 == true && pref2 == true ) {
+      "true"
+  } else {
+      "false"
   }
   EOS
 result:
-  string: 'true'
+  string: "true"
 fix: |
   This is implemented by a Configuration Profile.
 references:
@@ -47,7 +45,7 @@ references:
   cmmc:
     - CM.L2-3.4.5
 macOS:
-  - '26.0'
+  - "26.0"
 tags:
   - 800-53r5_low
   - 800-53r5_moderate

--- a/rules/system_settings/system_settings_guest_account_disable.yaml
+++ b/rules/system_settings/system_settings_guest_account_disable.yaml
@@ -6,20 +6,18 @@ discussion: |
   Turning off guest access prevents anonymous users from accessing files.
 check: |
   /usr/bin/osascript -l JavaScript << EOS
-  function run() {
-    let pref1 = ObjC.unwrap($.NSUserDefaults.alloc.initWithSuiteName('com.apple.MCX')\
+  let pref1 = ObjC.unwrap($.NSUserDefaults.alloc.initWithSuiteName('com.apple.MCX')\
   .objectForKey('DisableGuestAccount'))
-    let pref2 = ObjC.unwrap($.NSUserDefaults.alloc.initWithSuiteName('com.apple.MCX')\
+  let pref2 = ObjC.unwrap($.NSUserDefaults.alloc.initWithSuiteName('com.apple.MCX')\
   .objectForKey('EnableGuestAccount'))
-    if ( pref1 == true && pref2 == false ) {
-      return("true")
-    } else {
-      return("false")
-    }
+  if ( pref1 == true && pref2 == false ) {
+      "true"
+  } else {
+      "false"
   }
   EOS
 result:
-  string: 'true'
+  string: "true"
 fix: |
   This is implemented by a Configuration Profile.
 references:
@@ -50,7 +48,7 @@ references:
   cmmc:
     - AC.L1-3.1.2
 macOS:
-  - '26.0'
+  - "26.0"
 tags:
   - 800-53r5_low
   - 800-53r5_moderate

--- a/rules/system_settings/system_settings_media_sharing_disabled.yaml
+++ b/rules/system_settings/system_settings_media_sharing_disabled.yaml
@@ -8,20 +8,18 @@ discussion: |
   The information system _MUST_ be configured to provide only essential capabilities. Disabling Media Sharing helps prevent the unauthorized connection of devices and the unauthorized transfer of information. Disabling Media Sharing mitigates this risk.
 check: |
   /usr/bin/osascript -l JavaScript << EOS
-  function run() {
-    let pref1 = ObjC.unwrap($.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess')\
+  let pref1 = ObjC.unwrap($.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess')\
   .objectForKey('allowMediaSharing'))
-    let pref2 = ObjC.unwrap($.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess')\
+  let pref2 = ObjC.unwrap($.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess')\
   .objectForKey('allowMediaSharingModification'))
-    if ( pref1 == false && pref2 == false ) {
-      return("true")
-    } else {
-      return("false")
-    }
+  if ( pref1 == false && pref2 == false ) {
+      "true"
+  } else {
+      "false"
   }
   EOS
 result:
-  string: 'true'
+  string: "true"
 fix: |
   This is implemented by a Configuration Profile.
 references:
@@ -50,7 +48,7 @@ references:
   cmmc:
     - AC.L1-3.1.1
 macOS:
-  - '26.0'
+  - "26.0"
 tags:
   - 800-53r5_low
   - 800-53r5_moderate

--- a/rules/system_settings/system_settings_screensaver_ask_for_password_delay_enforce.yaml
+++ b/rules/system_settings/system_settings_screensaver_ask_for_password_delay_enforce.yaml
@@ -6,18 +6,16 @@ discussion: |
   An unattended system with an excessive grace period is vulnerable to a malicious user.
 check: |
   /usr/bin/osascript -l JavaScript << EOS
-  function run() {
-    let delay = ObjC.unwrap($.NSUserDefaults.alloc.initWithSuiteName('com.apple.screensaver')\
+  let delay = ObjC.unwrap($.NSUserDefaults.alloc.initWithSuiteName('com.apple.screensaver')\
   .objectForKey('askForPasswordDelay'))
-    if ( delay <= $ODV ) {
-      return("true")
-    } else {
-      return("false")
-    }
+  if ( delay <= $ODV ) {
+      "true"
+  } else {
+      "false"
   }
   EOS
 result:
-  string: 'true'
+  string: "true"
 fix: |
   This is implemented by a Configuration Profile.
 references:
@@ -43,7 +41,7 @@ references:
   cmmc:
     - AC.L2-3.1.10
 macOS:
-  - '26.0'
+  - "26.0"
 odv:
   hint: Number of seconds.
   recommended: 5

--- a/rules/system_settings/system_settings_screensaver_timeout_enforce.yaml
+++ b/rules/system_settings/system_settings_screensaver_timeout_enforce.yaml
@@ -6,18 +6,16 @@ discussion: |
   This rule ensures that a full session lock is triggered within no more than $ODV seconds of inactivity.
 check: |
   /usr/bin/osascript -l JavaScript << EOS
-  function run() {
-    let timeout = ObjC.unwrap($.NSUserDefaults.alloc.initWithSuiteName('com.apple.screensaver')\
+  let timeout = ObjC.unwrap($.NSUserDefaults.alloc.initWithSuiteName('com.apple.screensaver')\
   .objectForKey('idleTime'))
-    if ( timeout <= $ODV ) {
-      return("true")
-    } else {
-      return("false")
-    }
+  if ( timeout <= $ODV ) {
+      "true"
+  } else {
+      "false"
   }
   EOS
 result:
-  string: 'true'
+  string: "true"
 fix: |
   This is implemented by a Configuration Profile.
 references:
@@ -45,7 +43,7 @@ references:
   cmmc:
     - AC.L2-3.1.10
 macOS:
-  - '26.0'
+  - "26.0"
 odv:
   hint: Number of seconds.
   recommended: 1200

--- a/rules/system_settings/system_settings_usb_restricted_mode.yaml
+++ b/rules/system_settings/system_settings_usb_restricted_mode.yaml
@@ -9,18 +9,16 @@ discussion: |
   ====
 check: |
   /usr/bin/osascript -l JavaScript << EOS
-    function run() {
-      let pref1 = ObjC.unwrap($.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess')\
-    .objectForKey('allowUSBRestrictedMode'))
-      if ( pref1 == false ) {
-        return("false")
-      } else {
-        return("true")
-      }
-    }
+  let pref1 = ObjC.unwrap($.NSUserDefaults.alloc.initWithSuiteName('com.apple.applicationaccess')\
+  .objectForKey('allowUSBRestrictedMode'))
+  if ( pref1 == false ) {
+      "false"
+  } else {
+      "true"
+  }
   EOS
 result:
-  string: 'true'
+  string: "true"
 fix: |
   This is implemented by a Configuration Profile.
 references:
@@ -48,7 +46,7 @@ references:
   disa_stig:
     - APPL-26-005090
 macOS:
-  - '26.0'
+  - "26.0"
 tags:
   - 800-53r5_low
   - 800-53r5_moderate


### PR DESCRIPTION
macOS Tahoe 26 beta releases include a possible bug or change to the `run` function in JXA. The `run` function is actually only really useful for inputting command line arguments. 

As far as I can make out, the `$ODV` values are not submitted as command line arguments, rather they are substituted directly into the scripts on generation. Therefore, the run function is not required in any of the JXA snippets used in the mSCP.

This PR removes the run function from all snippets, which removes any potential issues with changes to the `run` function.