### PR TITLE
chore: update dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: bundler
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -25,15 +25,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Setup PNPM
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
         with:
-          version: 8
+          version: 10
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
-          node-version: "20"
+          node-version: "24"
           cache: pnpm
           cache-dependency-path: ${{ env.BUILD_PATH }}/pnpm-lock.yaml
       - name: Install dependencies
@@ -46,7 +46,7 @@ jobs:
             --base "${{ env.BASE_PATH }}"
         working-directory: ${{ env.BUILD_PATH }}
       - name: Upload to nist-pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ${{ env.BUILD_PATH }}/dist

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       # Checkout the branch that triggered the workflow
       - name: Checkout branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       # Pull latest cspell files from main to keep them in sync
       - name: Pull cspell config and dictionary from main
@@ -25,9 +25,9 @@ jobs:
 
       # Setup Node 20+ for cspell
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
-          node-version: '20'
+          node-version: '24'
 
       # Install cspell globally
       - name: Install cspell

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'asciidoctor', '2.0.22'
+gem 'asciidoctor', '2.0.26'
 gem 'asciidoctor-pdf'
-gem 'rouge', '3.30.0'
+gem 'rouge', '4.6.1'


### PR DESCRIPTION
### Chores
- Update gems and GitHub Actions (and improve security by SHA pinning)
- Update Node.js 20 to 24 (latest LTS)
- Update pnpm 8 to 10
- Let Dependabot update gems and GitHub Actions (pip ommitted)