### PR TITLE
Update overview.mdx

### DIFF
--- a/src/content/docs/mscp-2/overview.mdx
+++ b/src/content/docs/mscp-2/overview.mdx
@@ -166,7 +166,7 @@ Manual setup with virtual environment.
    source .venv/bin/activate
 
    # Install requirements
-   python3 -m pip install .
+   pip install -r requirements.txt
    ```
 
    <details>


### PR DESCRIPTION
If you are running the commands in order, a user might encounter the following bug: 

```txt
$ ./mscp.py baselines -l
Traceback (most recent call last):
  File "/<PATH>/macos_security/./mscp.py", line 8, in <module>
    from src.mscp.cli import parse_cli
  File "/<PATH>/macos_security/src/mscp/__init__.py", line 3, in <module>
    from loguru import logger
ModuleNotFoundError: No module named 'loguru'
```

Simply running `pip install -r requirements.txt` after you are in a new virtual environment should work and be more accurate. Otherwise you run the risk of being in a python virtual environment and downloading the packages in separate pyvenv. 

Added  photo evidence of the error and the last couple of commands ran:

<img width="2242" height="609" alt="2026-03-20_19-03-documentation-help" src="https://github.com/user-attachments/assets/d3398b56-e1c5-46aa-81d7-0084884f6b7e" />
