### PR TITLE
fix(pwpolicy_history_enforce): update CIS lvl1/lvl2 ODV from 15 to 24

### DIFF
--- a/rules/pwpolicy/pwpolicy_history_enforce.yaml
+++ b/rules/pwpolicy/pwpolicy_history_enforce.yaml
@@ -44,8 +44,8 @@ macOS:
 odv:
   hint: Number of previous passwords.
   recommended: 5
-  cis_lvl1: 15
-  cis_lvl2: 15
+  cis_lvl1: 24
+  cis_lvl2: 24
   stig: 5
 tags:
   - 800-171


### PR DESCRIPTION
CIS Benchmark for macOS 26 (section 5.2.8) updated the password history requirement from 15 to 24. Updates cis_lvl1 and cis_lvl2 ODV values accordingly.

Fixes #620