### PR TITLE
fix: Silicon update for SystemProfiler model name

### DIFF
--- a/rules/os/os_hibernate_mode_intel_enable.yaml
+++ b/rules/os/os_hibernate_mode_intel_enable.yaml
@@ -6,7 +6,7 @@ discussion: |
   This will store a copy of memory to persistent storage, and will remove power to memory. This setting will stop the potential for a cold-boot attack.
 check: |
   error_count=0
-  if /usr/sbin/ioreg -rd1 -c IOPlatformExpertDevice 2>&1 | /usr/bin/grep -q "MacBook"; then
+  if /usr/sbin/ioreg -rd1 -c IOPlatformExpertDevice 2>&1 | /usr/bin/grep -Ei "MacBook|Mac[0-9]"; then
     hibernateMode=$(/usr/bin/pmset -b -g | /usr/bin/grep hibernatemode 2>&1 | /usr/bin/awk '{print $2}')
     hibernateStandbyLowValue=$(/usr/bin/pmset -g | /usr/bin/grep standbydelaylow 2>&1 | /usr/bin/awk '{print $2}')
     hibernateStandbyHighValue=$(/usr/bin/pmset -g | /usr/bin/grep standbydelayhigh 2>&1 | /usr/bin/awk '{print $2}')

--- a/rules/os/os_sleep_and_display_sleep_apple_silicon_enable.yaml
+++ b/rules/os/os_sleep_and_display_sleep_apple_silicon_enable.yaml
@@ -4,7 +4,7 @@ discussion: |
   Apple Silicon MacBooks should set sleep timeout to 15 minutes (900 seconds) or less and the display sleep timeout should be 10 minutes (600 seconds) or less but less than the sleep setting.
 check: |
   error_count=0
-  if /usr/sbin/system_profiler SPHardwareDataType | /usr/bin/grep -q "MacBook"; then
+  if /usr/sbin/system_profiler SPHardwareDataType | /usr/bin/grep -Ei "MacBook|Mac[0-9]"; then
     cpuType=$(/usr/sbin/sysctl -n machdep.cpu.brand_string)
     if echo "$cpuType" | grep -q "Apple"; then
       sleepMode=$(/usr/bin/pmset -b -g | /usr/bin/grep '^\s*sleep' 2>&1 | /usr/bin/awk '{print $2}')


### PR DESCRIPTION
IOReg reports a different model name schema as of recent models. Updated to reflect the new model names.