### PR TITLE
NIST Pages Hero Fix & 2.0 Improvements

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -12,6 +12,9 @@ export default defineConfig({
 			logo: {
 				src: './src/assets/logo.png',
 			},
+			components: {
+				Hero: './src/components/Hero.astro',
+			},
 			customCss: [
 				// Path to your custom CSS file
 				'./src/styles/custom.css',

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -1,0 +1,146 @@
+---
+// Custom Hero override: removes the hardcoded height: 400 from Starlight's default,
+// so the image renders at its true aspect ratio instead of being forced into a 1:1 square.
+import { Image } from 'astro:assets';
+// PAGE_TITLE_ID is '_top' per @astrojs/starlight/constants.ts
+const PAGE_TITLE_ID = '_top';
+import LinkButton from '../../node_modules/@astrojs/starlight/user-components/LinkButton.astro';
+
+const { data } = Astro.locals.starlightRoute.entry;
+const { title = data.title, tagline, image, actions = [] } = data.hero || {};
+
+const imageAttrs = {
+	loading: 'eager' as const,
+	decoding: 'async' as const,
+	width: 400,
+	// No height — lets Astro resize proportionally and the browser use the real aspect ratio
+	alt: image?.alt || '',
+};
+
+let darkImage: ImageMetadata | undefined;
+let lightImage: ImageMetadata | undefined;
+let rawHtml: string | undefined;
+if (image) {
+	if ('file' in image) {
+		darkImage = image.file;
+	} else if ('dark' in image) {
+		darkImage = image.dark;
+		lightImage = image.light;
+	} else {
+		rawHtml = image.html;
+	}
+}
+---
+
+<div class="hero">
+	{
+		darkImage && (
+			<Image
+				src={darkImage}
+				{...imageAttrs}
+				class:list={{ 'light:sl-hidden print:hidden': Boolean(lightImage) }}
+			/>
+		)
+	}
+	{lightImage && <Image src={lightImage} {...imageAttrs} class="dark:sl-hidden" />}
+	{rawHtml && <div class="hero-html sl-flex" set:html={rawHtml} />}
+	<div class="sl-flex stack">
+		<div class="sl-flex copy">
+			<h1 id={PAGE_TITLE_ID} data-page-title set:html={title} />
+			{tagline && <div class="tagline" set:html={tagline} />}
+		</div>
+		{
+			actions.length > 0 && (
+				<div class="sl-flex actions">
+					{actions.map(
+						({ attrs: { class: className, ...attrs } = {}, icon, link: href, text, variant }) => (
+							<LinkButton {href} {variant} icon={icon?.name} class:list={[className]} {...attrs}>
+								{text}
+								{icon?.html && <Fragment set:html={icon.html} />}
+							</LinkButton>
+						)
+					)}
+				</div>
+			)
+		}
+	</div>
+</div>
+
+<style>
+	@layer starlight.core {
+		.hero {
+			display: grid;
+			align-items: center;
+			gap: 1rem;
+			padding-bottom: 1rem;
+		}
+
+		.hero > img,
+		.hero > .hero-html {
+			object-fit: contain;
+			width: min(70%, 20rem);
+			height: auto;
+			margin-inline: auto;
+		}
+
+		.stack {
+			flex-direction: column;
+			gap: clamp(1.5rem, calc(1.5rem + 1vw), 2rem);
+			text-align: center;
+		}
+
+		.copy {
+			flex-direction: column;
+			gap: 1rem;
+			align-items: center;
+		}
+
+		.copy > * {
+			max-width: 50ch;
+		}
+
+		h1 {
+			font-size: clamp(var(--sl-text-3xl), calc(0.25rem + 5vw), var(--sl-text-6xl));
+			line-height: var(--sl-line-height-headings);
+			font-weight: 600;
+			color: var(--sl-color-white);
+		}
+
+		.tagline {
+			font-size: clamp(var(--sl-text-base), calc(0.0625rem + 2vw), var(--sl-text-xl));
+			color: var(--sl-color-gray-2);
+		}
+
+		.actions {
+			gap: 1rem 2rem;
+			flex-wrap: wrap;
+			justify-content: center;
+		}
+
+		@media (min-width: 50rem) {
+			.hero {
+				grid-template-columns: 7fr 4fr;
+				gap: 3%;
+				padding-block: clamp(2.5rem, calc(1rem + 10vmin), 10rem);
+			}
+
+			.hero > img,
+			.hero > .hero-html {
+				order: 2;
+				width: min(100%, 25rem);
+			}
+
+			.stack {
+				text-align: start;
+			}
+
+			.copy {
+				align-items: flex-start;
+			}
+
+			.actions {
+				justify-content: flex-start;
+			}
+		}
+	}
+</style>

--- a/src/content/docs/baselines/baseline-file-layout.mdx
+++ b/src/content/docs/baselines/baseline-file-layout.mdx
@@ -12,12 +12,22 @@ A baseline file is a YAML document that defines which security rules apply to a 
 <Tabs syncKey="mscp-version">
   <TabItem label="mSCP 2.0 (Beta)">
 
+<Aside type="caution" title="mSCP 2.0 is currently in Beta">
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
+</Aside>
+
+
 <Aside type="tip">
 You don't need to create baseline files manually. The `./mscp.py baseline` command creates them for you. This page is for understanding what's inside.
 </Aside>
 
   </TabItem>
   <TabItem label="mSCP 1.0">
+
+<Aside type="caution" title="Always Use the Correct Branch">
+Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **Never use the `main` branch** — it won't work for generating content.
+</Aside>
+
 
 <Aside type="tip">
 You don't need to create baseline files manually. The `generate_baseline.py` script creates them for you. This page is for understanding what's inside.
@@ -69,6 +79,11 @@ Contributors who appear in generated documentation.
 <Tabs syncKey="mscp-version">
   <TabItem label="mSCP 2.0 (Beta)">
 
+<Aside type="caution" title="mSCP 2.0 is currently in Beta">
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
+</Aside>
+
+
 ```yaml
 authors:
   - name: John Smith
@@ -79,6 +94,11 @@ authors:
 
   </TabItem>
   <TabItem label="mSCP 1.0">
+
+<Aside type="caution" title="Always Use the Correct Branch">
+Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **Never use the `main` branch** — it won't work for generating content.
+</Aside>
+
 
 Listed in AsciiDoc table format:
 
@@ -143,6 +163,11 @@ profile:
 <Tabs syncKey="mscp-version">
   <TabItem label="mSCP 2.0 (Beta)">
 
+<Aside type="caution" title="mSCP 2.0 is currently in Beta">
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
+</Aside>
+
+
 ```yaml
 title: "macOS 26 (Tahoe): NIST 800-53r5 Moderate"
 description: |
@@ -175,6 +200,11 @@ profile:
 
   </TabItem>
   <TabItem label="mSCP 1.0">
+
+<Aside type="caution" title="Always Use the Correct Branch">
+Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **Never use the `main` branch** — it won't work for generating content.
+</Aside>
+
 
 ```yaml
 title: "macOS 15 (Sequoia): NIST 800-53r5 Moderate"

--- a/src/content/docs/baselines/how-to-generate-baselines.mdx
+++ b/src/content/docs/baselines/how-to-generate-baselines.mdx
@@ -17,7 +17,7 @@ Generating a baseline creates the YAML file that defines which security rules ap
   <TabItem label="mSCP 2.0 (Beta)">
 
 <Aside type="caution" title="mSCP 2.0 is currently in Beta">
-mSCP 2.0 may contain errors or unexpected issues. If you encounter any problems, please [report them to the project](https://github.com/usnistgov/macos_security/issues) — together we can make it a better solution.
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
 </Aside>
 
 <Steps>
@@ -96,12 +96,22 @@ Add the `-t` flag to customize the baseline for your organization:
 <Tabs syncKey="mscp-version">
   <TabItem label="mSCP 2.0 (Beta)">
 
+<Aside type="caution" title="mSCP 2.0 is currently in Beta">
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
+</Aside>
+
+
 ```bash
 ./mscp.py baseline -k 800-53r5_moderate -t
 ```
 
   </TabItem>
   <TabItem label="mSCP 1.0">
+
+<Aside type="caution" title="Always Use the Correct Branch">
+Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **Never use the `main` branch** — it won't work for generating content.
+</Aside>
+
 
 ```bash
 ./scripts/generate_baseline.py -k 800-53r5_moderate -t
@@ -127,6 +137,11 @@ Tailoring is optional. You can generate a baseline without customization and mod
 <Tabs syncKey="mscp-version">
   <TabItem label="mSCP 2.0 (Beta)">
 
+<Aside type="caution" title="mSCP 2.0 is currently in Beta">
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
+</Aside>
+
+
 | Flag | Description |
 |:-----|:------------|
 | `-l` | List all available baselines (tags and benchmarks) |
@@ -138,6 +153,11 @@ Tailoring is optional. You can generate a baseline without customization and mod
 
   </TabItem>
   <TabItem label="mSCP 1.0">
+
+<Aside type="caution" title="Always Use the Correct Branch">
+Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **Never use the `main` branch** — it won't work for generating content.
+</Aside>
+
 
 | Flag | Description |
 |:-----|:------------|
@@ -157,6 +177,11 @@ Tailoring is optional. You can generate a baseline without customization and mod
 <Tabs syncKey="mscp-version">
   <TabItem label="mSCP 2.0 (Beta)">
 
+<Aside type="caution" title="mSCP 2.0 is currently in Beta">
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
+</Aside>
+
+
 <FileTree>
 - macos_security/
     - config/
@@ -170,6 +195,11 @@ Tailoring is optional. You can generate a baseline without customization and mod
 
   </TabItem>
   <TabItem label="mSCP 1.0">
+
+<Aside type="caution" title="Always Use the Correct Branch">
+Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **Never use the `main` branch** — it won't work for generating content.
+</Aside>
+
 
 <FileTree>
 - macos_security/

--- a/src/content/docs/baselines/tailoring-a-baseline.mdx
+++ b/src/content/docs/baselines/tailoring-a-baseline.mdx
@@ -32,7 +32,7 @@ Consider tailoring when you need to:
   <TabItem label="mSCP 2.0 (Beta)">
 
 <Aside type="caution" title="mSCP 2.0 is currently in Beta">
-mSCP 2.0 may contain errors or unexpected issues. If you encounter any problems, please [report them to the project](https://github.com/usnistgov/macos_security/issues) — together we can make it a better solution.
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
 </Aside>
 
 <Steps>
@@ -191,6 +191,11 @@ This file overrides the default value for that rule. Your custom values are pres
 <Tabs syncKey="mscp-version">
   <TabItem label="mSCP 2.0 (Beta)">
 
+<Aside type="caution" title="mSCP 2.0 is currently in Beta">
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
+</Aside>
+
+
 ```bash
 # Generate a tailored NIST 800-53 Moderate baseline
 ./mscp.py baseline -k 800-53r5_moderate -t
@@ -201,6 +206,11 @@ This file overrides the default value for that rule. Your custom values are pres
 
   </TabItem>
   <TabItem label="mSCP 1.0">
+
+<Aside type="caution" title="Always Use the Correct Branch">
+Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **Never use the `main` branch** — it won't work for generating content.
+</Aside>
+
 
 ```bash
 # Generate a tailored NIST 800-53 Moderate baseline

--- a/src/content/docs/baselines/what-are-baselines.mdx
+++ b/src/content/docs/baselines/what-are-baselines.mdx
@@ -22,6 +22,11 @@ Think of a baseline as a shopping list of security settings. Your organization, 
 <Tabs syncKey="mscp-version">
   <TabItem label="mSCP 2.0 (Beta)">
 
+<Aside type="caution" title="mSCP 2.0 is currently in Beta">
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
+</Aside>
+
+
 1. **Choose a framework** — Pick the compliance standard you need (NIST, CIS, STIG, etc.)
 2. **Generate the baseline** — Run `./mscp.py baseline -k BASELINE_NAME` to create the YAML file
 3. **Customize if needed** — Tailor the baseline to your organization's requirements
@@ -29,6 +34,11 @@ Think of a baseline as a shopping list of security settings. Your organization, 
 
   </TabItem>
   <TabItem label="mSCP 1.0">
+
+<Aside type="caution" title="Always Use the Correct Branch">
+Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **Never use the `main` branch** — it won't work for generating content.
+</Aside>
+
 
 1. **Choose a framework** — Pick the compliance standard you need (NIST, CIS, STIG, etc.)
 2. **Generate the baseline** — Run `./scripts/generate_baseline.py -k BASELINE_NAME` to create the YAML file
@@ -84,6 +94,11 @@ CIS Level 2 baselines include all Level 1 rules plus additional controls for hig
 <Tabs syncKey="mscp-version">
   <TabItem label="mSCP 2.0 (Beta)">
 
+<Aside type="caution" title="mSCP 2.0 is currently in Beta">
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
+</Aside>
+
+
 ```bash
 ./mscp.py baseline -l
 ```
@@ -115,6 +130,11 @@ Benchmarks (platform-specific):
 
   </TabItem>
   <TabItem label="mSCP 1.0">
+
+<Aside type="caution" title="Always Use the Correct Branch">
+Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **Never use the `main` branch** — it won't work for generating content.
+</Aside>
+
 
 ```bash
 ./scripts/generate_baseline.py -l

--- a/src/content/docs/compliance-scripts/compliance-script-layout.mdx
+++ b/src/content/docs/compliance-scripts/compliance-script-layout.mdx
@@ -12,12 +12,22 @@ The compliance script is a zsh script with functions for checking settings, appl
 <Tabs syncKey="mscp-version">
   <TabItem label="mSCP 2.0 (Beta)">
 
+<Aside type="caution" title="mSCP 2.0 is currently in Beta">
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
+</Aside>
+
+
 <Aside type="tip">
 You don't need to modify the script manually. The `./mscp.py guidance -s` command creates it for you. This page explains what's inside.
 </Aside>
 
   </TabItem>
   <TabItem label="mSCP 1.0">
+
+<Aside type="caution" title="Always Use the Correct Branch">
+Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **Never use the `main` branch** — it won't work for generating content.
+</Aside>
+
 
 <Aside type="tip">
 You don't need to modify the script manually. The `./scripts/generate_guidance.py -s` script creates it for you. This page explains what's inside.

--- a/src/content/docs/compliance-scripts/how-to-generate-compliance-scripts.mdx
+++ b/src/content/docs/compliance-scripts/how-to-generate-compliance-scripts.mdx
@@ -21,7 +21,7 @@ You need a baseline first. See <a href={`${base}baselines/how-to-generate-baseli
   <TabItem label="mSCP 2.0 (Beta)">
 
 <Aside type="caution" title="mSCP 2.0 is currently in Beta">
-mSCP 2.0 may contain errors or unexpected issues. If you encounter any problems, please [report them to the project](https://github.com/usnistgov/macos_security/issues) — together we can make it a better solution.
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
 </Aside>
 
 <Steps>
@@ -103,12 +103,22 @@ Run with sudo for full access to system settings:
 <Tabs syncKey="mscp-version">
   <TabItem label="mSCP 2.0 (Beta)">
 
+<Aside type="caution" title="mSCP 2.0 is currently in Beta">
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
+</Aside>
+
+
 ```zsh
 sudo ./build/800-53r5_moderate_macos_26.0/800-53r5_moderate_macos_26.0_compliance.sh
 ```
 
   </TabItem>
   <TabItem label="mSCP 1.0">
+
+<Aside type="caution" title="Always Use the Correct Branch">
+Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **Never use the `main` branch** — it won't work for generating content.
+</Aside>
+
 
 ```zsh
 sudo ./build/800-53r5_moderate/800-53r5_moderate_compliance.sh

--- a/src/content/docs/configuration-profiles/configuration-profile-layout.mdx
+++ b/src/content/docs/configuration-profiles/configuration-profile-layout.mdx
@@ -12,12 +12,22 @@ Configuration profiles are XML files in Apple's property list (plist) format. Un
 <Tabs syncKey="mscp-version">
   <TabItem label="mSCP 2.0 (Beta)">
 
+<Aside type="caution" title="mSCP 2.0 is currently in Beta">
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
+</Aside>
+
+
 <Aside type="tip">
 You don't need to create profiles manually. The `./mscp.py guidance -p` command creates them for you. This page explains what's inside.
 </Aside>
 
   </TabItem>
   <TabItem label="mSCP 1.0">
+
+<Aside type="caution" title="Always Use the Correct Branch">
+Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **Never use the `main` branch** — it won't work for generating content.
+</Aside>
+
 
 <Aside type="tip">
 You don't need to create profiles manually. The `./scripts/generate_guidance.py -p` script creates them for you. This page explains what's inside.

--- a/src/content/docs/configuration-profiles/how-to-generate-configuration-profiles.mdx
+++ b/src/content/docs/configuration-profiles/how-to-generate-configuration-profiles.mdx
@@ -21,7 +21,7 @@ You need a baseline first. See <a href={`${base}baselines/how-to-generate-baseli
   <TabItem label="mSCP 2.0 (Beta)">
 
 <Aside type="caution" title="mSCP 2.0 is currently in Beta">
-mSCP 2.0 may contain errors or unexpected issues. If you encounter any problems, please [report them to the project](https://github.com/usnistgov/macos_security/issues) — together we can make it a better solution.
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
 </Aside>
 
 <Steps>
@@ -122,6 +122,11 @@ Replace `"Your Certificate Name"` with your signing certificate's common name.
 <Tabs syncKey="mscp-version">
   <TabItem label="mSCP 2.0 (Beta)">
 
+<Aside type="caution" title="mSCP 2.0 is currently in Beta">
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
+</Aside>
+
+
 ```bash
 ./mscp.py guidance custom/baselines/BASELINE_NAME.yaml -p -H SUBJECT_KEY_ID
 ```
@@ -133,6 +138,11 @@ Example:
 
   </TabItem>
   <TabItem label="mSCP 1.0">
+
+<Aside type="caution" title="Always Use the Correct Branch">
+Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **Never use the `main` branch** — it won't work for generating content.
+</Aside>
+
 
 ```bash
 ./scripts/generate_guidance.py -p -H SUBJECT_KEY_ID baselines/BASELINE_NAME.yaml
@@ -168,6 +178,11 @@ Signing is optional. Signed profiles verify the profile hasn't been modified and
 <Tabs syncKey="mscp-version">
   <TabItem label="mSCP 2.0 (Beta)">
 
+<Aside type="caution" title="mSCP 2.0 is currently in Beta">
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
+</Aside>
+
+
 | Flag | Description |
 |:-----|:------------|
 | `-p` | Generate individual profiles (one per payload type) |
@@ -177,6 +192,11 @@ Signing is optional. Signed profiles verify the profile hasn't been modified and
 
   </TabItem>
   <TabItem label="mSCP 1.0">
+
+<Aside type="caution" title="Always Use the Correct Branch">
+Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **Never use the `main` branch** — it won't work for generating content.
+</Aside>
+
 
 | Flag | Description |
 |:-----|:------------|
@@ -194,6 +214,11 @@ Signing is optional. Signed profiles verify the profile hasn't been modified and
 <Tabs syncKey="mscp-version">
   <TabItem label="mSCP 2.0 (Beta)">
 
+<Aside type="caution" title="mSCP 2.0 is currently in Beta">
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
+</Aside>
+
+
 | Type | Flag | Best For |
 |:-----|:-----|:---------|
 | **Individual** | `-p` | Flexibility — deploy only the profiles you need |
@@ -202,6 +227,11 @@ Signing is optional. Signed profiles verify the profile hasn't been modified and
 
   </TabItem>
   <TabItem label="mSCP 1.0">
+
+<Aside type="caution" title="Always Use the Correct Branch">
+Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **Never use the `main` branch** — it won't work for generating content.
+</Aside>
+
 
 | Type | Flag | Best For |
 |:-----|:-----|:---------|

--- a/src/content/docs/configuration-profiles/what-are-configuration-profiles.mdx
+++ b/src/content/docs/configuration-profiles/what-are-configuration-profiles.mdx
@@ -22,6 +22,11 @@ Configuration profiles enforce settings that users cannot override. This ensures
 <Tabs syncKey="mscp-version">
   <TabItem label="mSCP 2.0 (Beta)">
 
+<Aside type="caution" title="mSCP 2.0 is currently in Beta">
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
+</Aside>
+
+
 | Step | Description |
 |:-----|:------------|
 | **Generate** | Run `./mscp.py guidance -p` to create profiles from your baseline |
@@ -30,6 +35,11 @@ Configuration profiles enforce settings that users cannot override. This ensures
 
   </TabItem>
   <TabItem label="mSCP 1.0">
+
+<Aside type="caution" title="Always Use the Correct Branch">
+Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **Never use the `main` branch** — it won't work for generating content.
+</Aside>
+
 
 | Step | Description |
 |:-----|:------------|
@@ -49,6 +59,11 @@ Profiles can also be signed with a certificate (`-H` flag) to ensure authenticit
 <Tabs syncKey="mscp-version">
   <TabItem label="mSCP 2.0 (Beta)">
 
+<Aside type="caution" title="mSCP 2.0 is currently in Beta">
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
+</Aside>
+
+
 | Type | Flag | Description |
 |:-----|:-----|:------------|
 | **Individual profiles** | `-p` | One profile per payload type (recommended for flexibility) |
@@ -60,6 +75,11 @@ Output location: `build/BASELINE_NAME/mobileconfigs/`
 
   </TabItem>
   <TabItem label="mSCP 1.0">
+
+<Aside type="caution" title="Always Use the Correct Branch">
+Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **Never use the `main` branch** — it won't work for generating content.
+</Aside>
+
 
 | Type | Flag | Description |
 |:-----|:-----|:------------|

--- a/src/content/docs/ddm-components/ddm-component-layout.mdx
+++ b/src/content/docs/ddm-components/ddm-component-layout.mdx
@@ -12,12 +12,22 @@ DDM declarations are JSON files that define device configurations. Understanding
 <Tabs syncKey="mscp-version">
   <TabItem label="mSCP 2.0 (Beta)">
 
+<Aside type="caution" title="mSCP 2.0 is currently in Beta">
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
+</Aside>
+
+
 <Aside type="tip">
 You don't need to create declarations manually. The `./mscp.py guidance -d` command creates them for you. This page explains what's inside.
 </Aside>
 
   </TabItem>
   <TabItem label="mSCP 1.0">
+
+<Aside type="caution" title="Always Use the Correct Branch">
+Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **Never use the `main` branch** — it won't work for generating content.
+</Aside>
+
 
 <Aside type="tip">
 You don't need to create declarations manually. The `./scripts/generate_guidance.py -D` script creates them for you. This page explains what's inside.

--- a/src/content/docs/ddm-components/how-to-generate-ddm-components.mdx
+++ b/src/content/docs/ddm-components/how-to-generate-ddm-components.mdx
@@ -21,7 +21,7 @@ You need a baseline first. See <a href={`${base}baselines/how-to-generate-baseli
   <TabItem label="mSCP 2.0 (Beta)">
 
 <Aside type="caution" title="mSCP 2.0 is currently in Beta">
-mSCP 2.0 may contain errors or unexpected issues. If you encounter any problems, please [report them to the project](https://github.com/usnistgov/macos_security/issues) — together we can make it a better solution.
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
 </Aside>
 
 <Steps>
@@ -96,6 +96,11 @@ Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **
 <Tabs syncKey="mscp-version">
   <TabItem label="mSCP 2.0 (Beta)">
 
+<Aside type="caution" title="mSCP 2.0 is currently in Beta">
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
+</Aside>
+
+
 | Flag | Description |
 |:-----|:------------|
 | `-d` | Generate DDM declarations |
@@ -106,6 +111,11 @@ You can combine `-d` with other flags to generate multiple outputs at once. For 
 
   </TabItem>
   <TabItem label="mSCP 1.0">
+
+<Aside type="caution" title="Always Use the Correct Branch">
+Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **Never use the `main` branch** — it won't work for generating content.
+</Aside>
+
 
 | Flag | Description |
 |:-----|:------------|

--- a/src/content/docs/guidance/how-to-generate-guidance.mdx
+++ b/src/content/docs/guidance/how-to-generate-guidance.mdx
@@ -17,7 +17,7 @@ Generating guidance creates outputs from your baseline. By default it generates 
   <TabItem label="mSCP 2.0 (Beta)">
 
 <Aside type="caution" title="mSCP 2.0 is currently in Beta">
-mSCP 2.0 may contain errors or unexpected issues. If you encounter any problems, please [report them to the project](https://github.com/usnistgov/macos_security/issues) — together we can make it a better solution.
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
 </Aside>
 
 <Steps>
@@ -131,6 +131,11 @@ Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **
 <Tabs syncKey="mscp-version">
   <TabItem label="mSCP 2.0 (Beta)">
 
+<Aside type="caution" title="mSCP 2.0 is currently in Beta">
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
+</Aside>
+
+
 | Flag | Output |
 |:-----|:-------|
 | *(none)* | Guidance documents (.adoc, .html, .pdf) |
@@ -156,6 +161,11 @@ Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **
 
   </TabItem>
   <TabItem label="mSCP 1.0">
+
+<Aside type="caution" title="Always Use the Correct Branch">
+Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **Never use the `main` branch** — it won't work for generating content.
+</Aside>
+
 
 | Flag | Output |
 |:-----|:-------|
@@ -185,6 +195,11 @@ Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **
 
 <Tabs syncKey="mscp-version">
   <TabItem label="mSCP 2.0 (Beta)">
+
+<Aside type="caution" title="mSCP 2.0 is currently in Beta">
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
+</Aside>
+
 
 **Generate all outputs:**
 ```bash
@@ -219,6 +234,11 @@ Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **
   </TabItem>
   <TabItem label="mSCP 1.0">
 
+<Aside type="caution" title="Always Use the Correct Branch">
+Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **Never use the `main` branch** — it won't work for generating content.
+</Aside>
+
+
 **Generate documentation only:**
 ```bash
 ./scripts/generate_guidance.py baselines/800-53r5_moderate.yaml
@@ -249,6 +269,11 @@ Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **
 <Tabs syncKey="mscp-version">
   <TabItem label="mSCP 2.0 (Beta)">
 
+<Aside type="caution" title="mSCP 2.0 is currently in Beta">
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
+</Aside>
+
+
 | Type | Location | Use Case |
 |:-----|:---------|:---------|
 | **Generated** | `config/custom/baselines/` | Baselines created by `./mscp.py baseline` |
@@ -256,6 +281,11 @@ Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **
 
   </TabItem>
   <TabItem label="mSCP 1.0">
+
+<Aside type="caution" title="Always Use the Correct Branch">
+Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **Never use the `main` branch** — it won't work for generating content.
+</Aside>
+
 
 | Type | Location | Use Case |
 |:-----|:---------|:---------|

--- a/src/content/docs/guidance/what-is-guidance.mdx
+++ b/src/content/docs/guidance/what-is-guidance.mdx
@@ -12,10 +12,20 @@ export const base = import.meta.env.BASE_URL.endsWith('/') ? import.meta.env.BAS
 <Tabs syncKey="mscp-version">
   <TabItem label="mSCP 2.0 (Beta)">
 
+<Aside type="caution" title="mSCP 2.0 is currently in Beta">
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
+</Aside>
+
+
 Once you have a baseline, run `./mscp.py guidance` to create documentation in multiple formats.
 
   </TabItem>
   <TabItem label="mSCP 1.0">
+
+<Aside type="caution" title="Always Use the Correct Branch">
+Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **Never use the `main` branch** — it won't work for generating content.
+</Aside>
+
 
 Once you have a baseline, run `./scripts/generate_guidance.py` to create documentation in multiple formats.
 

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -37,7 +37,7 @@ export const base = import.meta.env.BASE_URL.endsWith('/') ? import.meta.env.BAS
   </ul>
   <div class="mscp2-promo-actions">
     <a href={`${base}mscp-2/overview/`} class="mscp2-promo-btn">What's New →</a>
-    <a href={`${base}welcome/getting-started/`} class="mscp2-promo-link">Try the Beta</a>
+    <a href={`${base}welcome/getting-started/`} class="mscp2-promo-link">Try the Beta &rarr;</a>
   </div>
 </div>
 

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -23,6 +23,24 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 
 export const base = import.meta.env.BASE_URL.endsWith('/') ? import.meta.env.BASE_URL : import.meta.env.BASE_URL + '/';
 
+<div class="mscp2-promo">
+  <div class="mscp2-promo-eyebrow">
+    Coming Soon <span class="mscp2-promo-badge">Beta</span>
+  </div>
+  <div class="mscp2-promo-title">mSCP 2.0 — The Next Generation</div>
+  <p class="mscp2-promo-desc">mSCP just got a whole lot better. One unified branch covers macOS, iOS/iPadOS, and visionOS. No more version juggling. Everything you need, in one place. Ready to test now.</p>
+  <ul class="mscp2-promo-features">
+    <li>Unified branch for all Apple OS versions</li>
+    <li>Container support (no more local dependencies)</li>
+    <li>Modern command-line tooling</li>
+    <li>Baselines, guidance, profiles, and scripts — all in one place</li>
+  </ul>
+  <div class="mscp2-promo-actions">
+    <a href={`${base}mscp-2/overview/`} class="mscp2-promo-btn">What's New →</a>
+    <a href={`${base}welcome/getting-started/`} class="mscp2-promo-link">Try the Beta</a>
+  </div>
+</div>
+
 ## Latest Release
 <div id="github-latest-release"></div>
 <script src={`${base}scripts/github-latest-release.js`}></script>

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -5,7 +5,7 @@ template: splash
 editUrl: false
 lastUpdated: false
 hero:
-  tagline: Comprehensive, open source macOS security guidance—built by federal experts, based on NIST SP 800-53 and 800-219, and recognized by Apple.
+  tagline: "Open source Apple OS security guidance (macOS, iOS/iPadOS, visionOS)—built by government and industry experts, based on <a href='https://csrc.nist.gov/pubs/sp/800/53/r5/upd1/final'>NIST SP 800-53</a>, authoritative per <a href='https://csrc.nist.gov/pubs/sp/800/219/r1/final'>SP 800-219</a> and <a href='https://csrc.nist.gov/pubs/sp/800/70/r5/ipd'>800-70</a>, with baselines and benchmarks for government, industry, and international use. <a href='https://support.apple.com/guide/certifications/macos-security-compliance-project-apc322685bb2/web'>Recognized by Apple</a>."
   image:
     file: ../../assets/logo.png
     class: hero-logo-effect

--- a/src/content/docs/mscp-2/overview.mdx
+++ b/src/content/docs/mscp-2/overview.mdx
@@ -7,13 +7,11 @@ import { Aside, Steps } from '@astrojs/starlight/components';
 
 export const base = import.meta.env.BASE_URL.endsWith('/') ? import.meta.env.BASE_URL : import.meta.env.BASE_URL + '/';
 
-<div class="beta-banner">
-  <span class="beta-tag">BETA</span>
-  <div class="beta-text">
-    <strong>mSCP 2.0 is currently in Beta</strong><br/>
-    mSCP 2.0 is under active development and should not be used in production. Please <a href="https://github.com/usnistgov/macos_security/issues">report any issues</a> to the project.<br/>
-    For production deployments, refer to <a href="https://github.com/usnistgov/macos_security">mSCP 1.0</a>.
+<div class="mscp2-promo mscp2-promo--beta">
+  <div class="mscp2-promo-eyebrow">
+    Currently in Beta <span class="mscp2-promo-badge">Beta</span>
   </div>
+  <p class="mscp2-promo-desc">mSCP 2.0 is under active development and should not be used in production. Please <a href="https://github.com/usnistgov/macos_security/issues">report any issues</a> to the project. For production deployments, refer to <a href="https://github.com/usnistgov/macos_security">mSCP 1.0</a>.</p>
 </div>
 
 mSCP 2.0 is a major architectural evolution — a **unified codebase** that eliminates the need for separate branches per macOS version.
@@ -379,36 +377,6 @@ Manual setup with virtual environment.
 - <a href={`${base}more-information/resources/`}>Resources</a> — Training and tools
 
 <style>{`
-  /* Beta Banner */
-  .beta-banner {
-    display: flex;
-    align-items: flex-start;
-    gap: 1rem;
-    background: linear-gradient(135deg, var(--sl-color-orange-low) 0%, var(--sl-color-yellow-low) 100%);
-    border: 2px solid var(--sl-color-orange);
-    border-radius: 12px;
-    padding: 1.25rem 1.5rem;
-    margin-bottom: 1.5rem;
-  }
-  .beta-tag {
-    background: var(--sl-color-orange);
-    color: var(--sl-color-black);
-    font-weight: 800;
-    font-size: 0.75rem;
-    padding: 0.35rem 0.75rem;
-    border-radius: 6px;
-    letter-spacing: 0.05em;
-    flex-shrink: 0;
-  }
-  .beta-text {
-    font-size: 0.95rem;
-    line-height: 1.5;
-  }
-  .beta-text a {
-    color: var(--sl-color-orange-high);
-    font-weight: 600;
-  }
-
   /* Rule Compare */
   .rule-compare {
     background: var(--sl-color-bg-inline-code);

--- a/src/content/docs/mscp-2/overview.mdx
+++ b/src/content/docs/mscp-2/overview.mdx
@@ -10,9 +10,9 @@ export const base = import.meta.env.BASE_URL.endsWith('/') ? import.meta.env.BAS
 <div class="beta-banner">
   <span class="beta-tag">BETA</span>
   <div class="beta-text">
-    <strong>mSCP 2.0 is in active development</strong><br/>
-    Available on the <a href="https://github.com/usnistgov/macos_security/tree/dev_2.0">dev_2.0 branch</a>. Not for production use.<br/>
-    All information is subject to change.
+    <strong>mSCP 2.0 is currently in Beta</strong><br/>
+    mSCP 2.0 is under active development and should not be used in production. Please <a href="https://github.com/usnistgov/macos_security/issues">report any issues</a> to the project.<br/>
+    For production deployments, refer to <a href="https://github.com/usnistgov/macos_security">mSCP 1.0</a>.
   </div>
 </div>
 

--- a/src/content/docs/other/generate-mapping.mdx
+++ b/src/content/docs/other/generate-mapping.mdx
@@ -42,7 +42,7 @@ The first row should contain the framework names:
   <TabItem label="mSCP 2.0 (Beta)">
 
 <Aside type="caution" title="mSCP 2.0 is currently in Beta">
-mSCP 2.0 may contain errors or unexpected issues. If you encounter any problems, please [report them to the project](https://github.com/usnistgov/macos_security/issues) — together we can make it a better solution.
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
 </Aside>
 
 <Steps>
@@ -106,6 +106,11 @@ Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **
 <Tabs syncKey="mscp-version">
   <TabItem label="mSCP 2.0 (Beta)">
 
+<Aside type="caution" title="mSCP 2.0 is currently in Beta">
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
+</Aside>
+
+
 | Flag | Description |
 |:-----|:------------|
 | `-c CSV_FILE` | Path to CSV mapping file (required) |
@@ -118,6 +123,11 @@ Example mapping to CIS Controls:
 
   </TabItem>
   <TabItem label="mSCP 1.0">
+
+<Aside type="caution" title="Always Use the Correct Branch">
+Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **Never use the `main` branch** — it won't work for generating content.
+</Aside>
+
 
 | Flag | Description |
 |:-----|:------------|

--- a/src/content/docs/other/generate-scap.mdx
+++ b/src/content/docs/other/generate-scap.mdx
@@ -27,7 +27,7 @@ The SCAP script creates security compliance documents in SCAP (Security Content 
   <TabItem label="mSCP 2.0 (Beta)">
 
 <Aside type="caution" title="mSCP 2.0 is currently in Beta">
-mSCP 2.0 may contain errors or unexpected issues. If you encounter any problems, please [report them to the project](https://github.com/usnistgov/macos_security/issues) — together we can make it a better solution.
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
 </Aside>
 
 <Steps>
@@ -111,6 +111,11 @@ Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **
 <Tabs syncKey="mscp-version">
   <TabItem label="mSCP 2.0 (Beta)">
 
+<Aside type="caution" title="mSCP 2.0 is currently in Beta">
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
+</Aside>
+
+
 | Flag | Description |
 |:-----|:------------|
 | `-l` | List available baseline tags |
@@ -121,6 +126,11 @@ Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **
 
   </TabItem>
   <TabItem label="mSCP 1.0">
+
+<Aside type="caution" title="Always Use the Correct Branch">
+Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **Never use the `main` branch** — it won't work for generating content.
+</Aside>
+
 
 | Flag | Description |
 |:-----|:------------|

--- a/src/content/docs/personalization/customize-rules.mdx
+++ b/src/content/docs/personalization/customize-rules.mdx
@@ -55,12 +55,22 @@ When you create a custom rule file, the project:
 <Tabs syncKey="mscp-version">
   <TabItem label="mSCP 2.0 (Beta)">
 
+<Aside type="caution" title="mSCP 2.0 is currently in Beta">
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
+</Aside>
+
+
 ```bash
 ./mscp.py guidance custom/baselines/YOUR_BASELINE.yaml
 ```
 
   </TabItem>
   <TabItem label="mSCP 1.0">
+
+<Aside type="caution" title="Always Use the Correct Branch">
+Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **Never use the `main` branch** — it won't work for generating content.
+</Aside>
+
 
 ```bash
 ./scripts/generate_guidance.py baselines/YOUR_BASELINE.yaml
@@ -104,6 +114,11 @@ The custom values merge with the original rule automatically.
 <Tabs syncKey="mscp-version">
   <TabItem label="mSCP 2.0 (Beta)">
 
+<Aside type="caution" title="mSCP 2.0 is currently in Beta">
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
+</Aside>
+
+
 ```bash
 # Generate baseline
 ./mscp.py baseline -k YOUR_TAG
@@ -114,6 +129,11 @@ The custom values merge with the original rule automatically.
 
   </TabItem>
   <TabItem label="mSCP 1.0">
+
+<Aside type="caution" title="Always Use the Correct Branch">
+Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **Never use the `main` branch** — it won't work for generating content.
+</Aside>
+
 
 ```bash
 # Generate baseline

--- a/src/content/docs/personalization/exempting-rules.mdx
+++ b/src/content/docs/personalization/exempting-rules.mdx
@@ -83,12 +83,22 @@ The compliance script checks for managed preferences and respects exemptions set
 <Tabs syncKey="mscp-version">
   <TabItem label="mSCP 2.0 (Beta)">
 
+<Aside type="caution" title="mSCP 2.0 is currently in Beta">
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
+</Aside>
+
+
 <Aside type="tip">
 When generating compliance outputs with `./mscp.py guidance -s`, the project creates a default audit plist in `build/{baseline}/preferences/` that you can use as a template for your MDM deployment.
 </Aside>
 
   </TabItem>
   <TabItem label="mSCP 1.0">
+
+<Aside type="caution" title="Always Use the Correct Branch">
+Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **Never use the `main` branch** — it won't work for generating content.
+</Aside>
+
 
 <Aside type="tip">
 When generating compliance outputs with `./scripts/generate_guidance.py -s`, the project creates a default audit plist in `build/{baseline}/preferences/` that you can use as a template for your MDM deployment.

--- a/src/content/docs/personalization/tailoring-rules.mdx
+++ b/src/content/docs/personalization/tailoring-rules.mdx
@@ -21,7 +21,7 @@ Tailoring lets you create a customized baseline by choosing which rules to inclu
   <TabItem label="mSCP 2.0 (Beta)">
 
 <Aside type="caution" title="mSCP 2.0 is currently in Beta">
-mSCP 2.0 may contain errors or unexpected issues. If you encounter any problems, please [report them to the project](https://github.com/usnistgov/macos_security/issues) — together we can make it a better solution.
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
 </Aside>
 
 <Steps>
@@ -143,12 +143,22 @@ Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **
 <Tabs syncKey="mscp-version">
   <TabItem label="mSCP 2.0 (Beta)">
 
+<Aside type="caution" title="mSCP 2.0 is currently in Beta">
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
+</Aside>
+
+
 ```bash
 ./mscp.py guidance custom/baselines/MyOrgs_Benchmark_macos_26.0.yaml -A
 ```
 
   </TabItem>
   <TabItem label="mSCP 1.0">
+
+<Aside type="caution" title="Always Use the Correct Branch">
+Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **Never use the `main` branch** — it won't work for generating content.
+</Aside>
+
 
 ```bash
 ./scripts/generate_guidance.py build/baselines/MyOrgs_Benchmark.yaml -p -s

--- a/src/content/docs/repository/Includes-directory.mdx
+++ b/src/content/docs/repository/Includes-directory.mdx
@@ -16,6 +16,11 @@ The includes directory contains supporting files used by the generation scripts.
 <Tabs syncKey="mscp-version">
   <TabItem label="mSCP 2.0 (Beta)">
 
+<Aside type="caution" title="mSCP 2.0 is currently in Beta">
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
+</Aside>
+
+
 Located in `config/includes/`:
 
 | File | Description |
@@ -30,6 +35,11 @@ Located in `config/includes/`:
 
   </TabItem>
   <TabItem label="mSCP 1.0">
+
+<Aside type="caution" title="Always Use the Correct Branch">
+Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **Never use the `main` branch** — it won't work for generating content.
+</Aside>
+
 
 Located in `includes/`:
 
@@ -53,6 +63,11 @@ Located in `includes/`:
 <Tabs syncKey="mscp-version">
   <TabItem label="mSCP 2.0 (Beta)">
 
+<Aside type="caution" title="mSCP 2.0 is currently in Beta">
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
+</Aside>
+
+
 **800-53_baselines.yaml** — Contains the NIST 800-53 control mappings used by the `-c` flag in `./mscp.py baseline` to output controls covered by rules.
 
 **mscp-data.yaml** — Project-wide metadata including version information, supported platforms, and default settings.
@@ -61,6 +76,11 @@ Located in `includes/`:
 
   </TabItem>
   <TabItem label="mSCP 1.0">
+
+<Aside type="caution" title="Always Use the Correct Branch">
+Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **Never use the `main` branch** — it won't work for generating content.
+</Aside>
+
 
 **supported_payloads.yaml** — Defines which configuration profile payloads the project supports. When adding custom rules that use new payloads, add them here.
 
@@ -78,6 +98,11 @@ Located in `includes/`:
 <Tabs syncKey="mscp-version">
   <TabItem label="mSCP 2.0 (Beta)">
 
+<Aside type="caution" title="mSCP 2.0 is currently in Beta">
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
+</Aside>
+
+
 <FileTree>
 - config/includes/
     - 800-53_baselines.yaml
@@ -91,6 +116,11 @@ Located in `includes/`:
 
   </TabItem>
   <TabItem label="mSCP 1.0">
+
+<Aside type="caution" title="Always Use the Correct Branch">
+Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **Never use the `main` branch** — it won't work for generating content.
+</Aside>
+
 
 <FileTree>
 - includes/

--- a/src/content/docs/repository/directory-layout.mdx
+++ b/src/content/docs/repository/directory-layout.mdx
@@ -16,6 +16,11 @@ This page describes the directory structure of the macOS Security Compliance Pro
 <Tabs syncKey="mscp-version">
   <TabItem label="mSCP 2.0 (Beta)">
 
+<Aside type="caution" title="mSCP 2.0 is currently in Beta">
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
+</Aside>
+
+
 <FileTree>
 - config/
     - default/
@@ -44,6 +49,11 @@ This page describes the directory structure of the macOS Security Compliance Pro
   </TabItem>
   <TabItem label="mSCP 1.0">
 
+<Aside type="caution" title="Always Use the Correct Branch">
+Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **Never use the `main` branch** — it won't work for generating content.
+</Aside>
+
+
 <FileTree>
 - baselines/ Baseline YAML files for compliance frameworks
 - build/ Generated output files
@@ -67,6 +77,11 @@ The rules directory contains subdirectories organized by category:
 <Tabs syncKey="mscp-version">
   <TabItem label="mSCP 2.0 (Beta)">
 
+<Aside type="caution" title="mSCP 2.0 is currently in Beta">
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
+</Aside>
+
+
 | Category | Description |
 |:---------|:------------|
 | `audit/` | OpenBSM auditing settings |
@@ -79,6 +94,11 @@ The rules directory contains subdirectories organized by category:
 
   </TabItem>
   <TabItem label="mSCP 1.0">
+
+<Aside type="caution" title="Always Use the Correct Branch">
+Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **Never use the `main` branch** — it won't work for generating content.
+</Aside>
+
 
 | Category | Description |
 |:---------|:------------|
@@ -100,6 +120,11 @@ The rules directory contains subdirectories organized by category:
 <Tabs syncKey="mscp-version">
   <TabItem label="mSCP 2.0 (Beta)">
 
+<Aside type="caution" title="mSCP 2.0 is currently in Beta">
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
+</Aside>
+
+
 <FileTree>
 - config/custom/
     - rules/ Custom rule overrides
@@ -111,6 +136,11 @@ The rules directory contains subdirectories organized by category:
 
   </TabItem>
   <TabItem label="mSCP 1.0">
+
+<Aside type="caution" title="Always Use the Correct Branch">
+Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **Never use the `main` branch** — it won't work for generating content.
+</Aside>
+
 
 <FileTree>
 - custom/

--- a/src/content/docs/repository/rule-file-layout.mdx
+++ b/src/content/docs/repository/rule-file-layout.mdx
@@ -16,6 +16,11 @@ A rule file defines a single security control. Each rule is written in YAML and 
 <Tabs syncKey="mscp-version">
   <TabItem label="mSCP 2.0 (Beta)">
 
+<Aside type="caution" title="mSCP 2.0 is currently in Beta">
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
+</Aside>
+
+
 | Field | Description |
 |:------|:------------|
 | `id` | Unique identifier matching the filename (without `.yaml`) |
@@ -27,6 +32,11 @@ A rule file defines a single security control. Each rule is written in YAML and 
 
   </TabItem>
   <TabItem label="mSCP 1.0">
+
+<Aside type="caution" title="Always Use the Correct Branch">
+Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **Never use the `main` branch** — it won't work for generating content.
+</Aside>
+
 
 | Field | Description |
 |:------|:------------|
@@ -48,6 +58,11 @@ A rule file defines a single security control. Each rule is written in YAML and 
 <Tabs syncKey="mscp-version">
   <TabItem label="mSCP 2.0 (Beta)">
 
+<Aside type="caution" title="mSCP 2.0 is currently in Beta">
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
+</Aside>
+
+
 | Field | Description |
 |:------|:------------|
 | `odv` | Organization Defined Values with hint and defaults |
@@ -58,6 +73,11 @@ A rule file defines a single security control. Each rule is written in YAML and 
 
   </TabItem>
   <TabItem label="mSCP 1.0">
+
+<Aside type="caution" title="Always Use the Correct Branch">
+Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **Never use the `main` branch** — it won't work for generating content.
+</Aside>
+
 
 | Field | Description |
 |:------|:------------|
@@ -78,6 +98,11 @@ A rule file defines a single security control. Each rule is written in YAML and 
 
 <Tabs syncKey="mscp-version">
   <TabItem label="mSCP 2.0 (Beta)">
+
+<Aside type="caution" title="mSCP 2.0 is currently in Beta">
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
+</Aside>
+
 
 References are nested by source organization:
 
@@ -101,6 +126,11 @@ references:
   </TabItem>
   <TabItem label="mSCP 1.0">
 
+<Aside type="caution" title="Always Use the Correct Branch">
+Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **Never use the `main` branch** — it won't work for generating content.
+</Aside>
+
+
 References are flat key-value pairs:
 
 | Key | Framework |
@@ -123,6 +153,11 @@ References are flat key-value pairs:
 
 <Tabs syncKey="mscp-version">
   <TabItem label="mSCP 2.0 (Beta)">
+
+<Aside type="caution" title="mSCP 2.0 is currently in Beta">
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
+</Aside>
+
 
 ```yaml
 id: os_authenticated_root_enable
@@ -184,6 +219,11 @@ mobileconfig: false
 
   </TabItem>
   <TabItem label="mSCP 1.0">
+
+<Aside type="caution" title="Always Use the Correct Branch">
+Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **Never use the `main` branch** — it won't work for generating content.
+</Aside>
+
 
 ```yaml
 id: system_settings_bluetooth_disable

--- a/src/content/docs/repository/script-arguments-list.mdx
+++ b/src/content/docs/repository/script-arguments-list.mdx
@@ -12,6 +12,11 @@ This page documents the command-line arguments for the generation scripts.
 <Tabs syncKey="mscp-version">
   <TabItem label="mSCP 2.0 (Beta)">
 
+<Aside type="caution" title="mSCP 2.0 is currently in Beta">
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
+</Aside>
+
+
 ---
 
 ### mscp.py guidance
@@ -98,6 +103,11 @@ Creates custom rules and baselines for unsupported compliance frameworks.
 
   </TabItem>
   <TabItem label="mSCP 1.0">
+
+<Aside type="caution" title="Always Use the Correct Branch">
+Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **Never use the `main` branch** — it won't work for generating content.
+</Aside>
+
 
 ---
 

--- a/src/content/docs/repository/sections-file-layout.mdx
+++ b/src/content/docs/repository/sections-file-layout.mdx
@@ -12,10 +12,20 @@ Section files define the major sections of your security guide. Each section fil
 <Tabs syncKey="mscp-version">
   <TabItem label="mSCP 2.0 (Beta)">
 
+<Aside type="caution" title="mSCP 2.0 is currently in Beta">
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
+</Aside>
+
+
 Section files are located in `config/default/sections/`. Custom sections go in `config/custom/sections/`.
 
   </TabItem>
   <TabItem label="mSCP 1.0">
+
+<Aside type="caution" title="Always Use the Correct Branch">
+Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **Never use the `main` branch** — it won't work for generating content.
+</Aside>
+
 
 Section files are located in `sections/`. Custom sections go in `custom/sections/`.
 
@@ -50,6 +60,11 @@ description: |
 <Tabs syncKey="mscp-version">
   <TabItem label="mSCP 2.0 (Beta)">
 
+<Aside type="caution" title="mSCP 2.0 is currently in Beta">
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
+</Aside>
+
+
 | Section | Description |
 |:--------|:------------|
 | `auditing.yaml` | OpenBSM audit configuration |
@@ -68,6 +83,11 @@ description: |
 
   </TabItem>
   <TabItem label="mSCP 1.0">
+
+<Aside type="caution" title="Always Use the Correct Branch">
+Each macOS version has its own branch (`sequoia`, `sonoma`, `ventura`, etc.). **Never use the `main` branch** — it won't work for generating content.
+</Aside>
+
 
 | Section | Description |
 |:--------|:------------|

--- a/src/content/docs/welcome/getting-started.mdx
+++ b/src/content/docs/welcome/getting-started.mdx
@@ -24,7 +24,7 @@ Decide which version to set up with, then follow the steps below.
   <TabItem label="mSCP 2.0 (Beta)">
 
 <Aside type="caution" title="mSCP 2.0 is currently in Beta">
-mSCP 2.0 may contain errors or unexpected issues. If you encounter any problems, please [report them to the project](https://github.com/usnistgov/macos_security/issues) — together we can make it a better solution.
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
 </Aside>
 
 <Tabs syncKey="mscp2-method">

--- a/src/content/docs/welcome/quick-guide.mdx
+++ b/src/content/docs/welcome/quick-guide.mdx
@@ -62,7 +62,7 @@ A complete start to finish walkthrough of the macOS Security Compliance Project.
   <TabItem label="mSCP 2.0 (Beta)">
 
 <Aside type="caution" title="mSCP 2.0 is currently in Beta">
-mSCP 2.0 may contain errors or unexpected issues. If you encounter any problems, please [report them to the project](https://github.com/usnistgov/macos_security/issues) — together we can make it a better solution.
+mSCP 2.0 is under active development and should not be used in production. Please [report any issues](https://github.com/usnistgov/macos_security/issues) to the project. For production deployments, refer to [mSCP 1.0](https://github.com/usnistgov/macos_security).
 </Aside>
 
 <div class="section-heading">Quick Start (Container)</div>

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -114,6 +114,194 @@ sl-anchor-link,
 /* mSCP 2.0 Overview Page Styles */
 /* ---------------------------------------------------------------------- */
 
+/* ---------------------------------------------------------------------- */
+/* mSCP 2.0 Promo Banner (home page) */
+/* ---------------------------------------------------------------------- */
+
+@keyframes mscp2-glow {
+  0%, 100% {
+    box-shadow: 0 0 6px rgba(49, 100, 49, 0.2), 0 0 0 1px rgba(49, 100, 49, 0.15);
+  }
+  50% {
+    box-shadow: 0 0 22px rgba(49, 100, 49, 0.45), 0 0 0 1px rgba(49, 100, 49, 0.4);
+  }
+}
+
+@keyframes mscp2-glow-dark {
+  0%, 100% {
+    box-shadow: 0 0 8px rgba(106, 181, 73, 0.2), 0 0 0 1px rgba(106, 181, 73, 0.15);
+  }
+  50% {
+    box-shadow: 0 0 28px rgba(106, 181, 73, 0.5), 0 0 0 1px rgba(106, 181, 73, 0.45);
+  }
+}
+
+.mscp2-promo {
+  border-radius: 8px;
+  padding: 1em 1.25em;
+  margin: 1em 0;
+  border: 1px solid rgba(49, 100, 49, 0.25);
+  background: transparent;
+  color: var(--sl-color-text, #333);
+  animation: mscp2-glow 3s ease-in-out infinite;
+}
+
+.mscp2-promo:hover {
+  animation-play-state: paused;
+  box-shadow: 0 0 30px rgba(49, 100, 49, 0.5), 0 0 0 1px rgba(49, 100, 49, 0.5);
+}
+
+[data-theme="dark"] .mscp2-promo {
+  border-color: rgba(106, 181, 73, 0.25);
+  animation-name: mscp2-glow-dark;
+}
+
+[data-theme="dark"] .mscp2-promo:hover {
+  box-shadow: 0 0 30px rgba(106, 181, 73, 0.55), 0 0 0 1px rgba(106, 181, 73, 0.5);
+}
+
+.mscp2-promo-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.mscp2-promo-icon {
+  color: var(--sl-color-accent, #316431);
+  flex-shrink: 0;
+  opacity: 0.7;
+}
+
+[data-theme="dark"] .mscp2-promo-icon {
+  color: var(--sl-color-accent-high, #6ab549);
+  opacity: 0.8;
+}
+
+.mscp2-promo-title-group {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.mscp2-promo-title {
+  font-size: clamp(1.4rem, 3vw, 2rem);
+  font-weight: 700;
+  color: var(--sl-color-white);
+  line-height: 1.2;
+}
+
+.mscp2-promo-badge {
+  background: #f5a623;
+  color: #111;
+  font-size: 0.75em;
+  font-weight: 600;
+  padding: 0.2em 0.6em;
+  border-radius: 4px;
+}
+
+.mscp2-promo-eyebrow {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin-bottom: 0.6rem;
+  font-size: 0.75em;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--sl-color-accent-high);
+}
+
+.mscp2-promo-desc {
+  display: block;
+  width: 100%;
+  font-size: 0.95em;
+  color: var(--sl-color-text, #444);
+  margin: 0.75em 0;
+  line-height: 1.6;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+}
+
+[data-theme="dark"] .mscp2-promo-desc {
+  color: var(--sl-color-text, #ccc);
+}
+
+.mscp2-promo-features {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.35rem 2rem;
+  margin: 0 0 1rem;
+  padding: 0;
+  list-style: none;
+  color: var(--sl-color-gray-2);
+  font-size: 0.9em;
+}
+
+@media (max-width: 40rem) {
+  .mscp2-promo-features {
+    grid-template-columns: 1fr;
+  }
+}
+
+.mscp2-promo-features li::before {
+  content: '✓  ';
+  color: var(--sl-color-accent, #316431);
+  font-weight: 700;
+}
+
+[data-theme="dark"] .mscp2-promo-features li::before {
+  color: var(--sl-color-accent-high, #6ab549);
+}
+
+.mscp2-promo-actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-top: 1rem;
+  flex-wrap: wrap;
+}
+
+.mscp2-promo-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: var(--sl-color-accent, #316431);
+  color: #fff !important;
+  padding: 0.5em 1em;
+  border-radius: 6px;
+  font-size: 0.9em;
+  font-weight: 500;
+  text-decoration: none !important;
+  transition: background 0.2s, transform 0.2s;
+}
+
+.mscp2-promo-btn:hover {
+  opacity: 0.9;
+  transform: translateY(-1px);
+}
+
+[data-theme="dark"] .mscp2-promo-btn {
+  background: var(--sl-color-accent-high, #6ab549);
+  color: #111 !important;
+}
+
+.mscp2-promo-link {
+  color: var(--sl-color-accent, #316431);
+  font-size: 0.9em;
+  text-decoration: none;
+}
+
+.mscp2-promo-link:hover {
+  text-decoration: underline;
+}
+
+[data-theme="dark"] .mscp2-promo-link {
+  color: var(--sl-color-accent-high, #6ab549);
+}
+
+/* ---------------------------------------------------------------------- */
 /* Feature boxes hover effect */
 .feature-box {
   transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -160,6 +160,43 @@ sl-anchor-link,
   box-shadow: 0 0 30px rgba(106, 181, 73, 0.55), 0 0 0 1px rgba(106, 181, 73, 0.5);
 }
 
+.mscp2-promo--beta {
+  animation: none;
+  border-color: rgba(234, 197, 30, 0.45);
+  background: rgba(234, 197, 30, 0.08);
+}
+
+[data-theme="dark"] .mscp2-promo--beta {
+  background: rgba(234, 197, 30, 0.06);
+}
+
+.mscp2-promo--beta:hover {
+  box-shadow: none;
+  border-color: rgba(234, 197, 30, 0.75);
+}
+
+[data-theme="dark"] .mscp2-promo--beta {
+  border-color: rgba(234, 197, 30, 0.4);
+}
+
+[data-theme="dark"] .mscp2-promo--beta:hover {
+  box-shadow: none;
+  border-color: rgba(234, 197, 30, 0.7);
+}
+
+.mscp2-promo--beta .mscp2-promo-eyebrow {
+  color: #a07c00;
+}
+
+[data-theme="dark"] .mscp2-promo--beta .mscp2-promo-eyebrow {
+  color: #eac51e;
+}
+
+.mscp2-promo--beta .mscp2-promo-badge {
+  background: #eac51e;
+  color: #111;
+}
+
 .mscp2-promo-header {
   display: flex;
   align-items: center;

--- a/src/styles/home_page.css
+++ b/src/styles/home_page.css
@@ -6,6 +6,8 @@
     width: min(90%, 32rem);
     height: auto;
     margin-inline: auto;
+    /* Padding compensates for visual overflow caused by rotation/scale transform */
+    padding-block: 3.5rem;
     /* Initial rotation and scale */
     transform: rotate(12deg) scale(1.05);
     transition: all 0.3s;


### PR DESCRIPTION
## Documentation & Site Improvements

  ### mSCP 2.0
  - Ensured all mSCP 2.0 (Beta) tab sections include the beta warning
  - Improved beta warning copy — clearer language, links to report issues and reference mSCP 1.0 for production use
  - Added mSCP 2.0 feature announcement to the home page

  ### mSCP 1.0
  - Ensured all mSCP 1.0 tab sections include the branch selection warning

  ### Hero
  - Fixed hero image clipping on larger and smaller screens caused by upstream Astro build changes
  - Updated hero tagline with expanded scope and hyperlinks to NIST SP 800-53, 800-219, 800-70, and the Apple recognition page