### PR TITLE
Replace deprecated com.apple.SoftwareUpdate payload with supported configuration

### DIFF
--- a/rules/system_settings/system_settings_critical_update_install_enforce.yaml
+++ b/rules/system_settings/system_settings_critical_update_install_enforce.yaml
@@ -54,3 +54,8 @@ mobileconfig: true
 mobileconfig_info:
   com.apple.SoftwareUpdate:
     CriticalUpdateInstall: true
+ddm_info:
+  declarationtype: com.apple.configuration.softwareupdate.settings
+  ddm_key: AutomaticActions
+  ddm_value:
+    InstallSecurityUpdates: AlwaysOn

--- a/rules/system_settings/system_settings_install_macos_updates_enforce.yaml
+++ b/rules/system_settings/system_settings_install_macos_updates_enforce.yaml
@@ -42,3 +42,8 @@ mobileconfig: true
 mobileconfig_info:
   com.apple.SoftwareUpdate:
     AutomaticallyInstallMacOSUpdates: true
+ddm_info:
+  declarationtype: com.apple.configuration.softwareupdate.settings
+  ddm_key: AutomaticActions
+  ddm_value:
+    InstallOSUpdates: AlwaysOn

--- a/rules/system_settings/system_settings_software_update_download_enforce.yaml
+++ b/rules/system_settings/system_settings_software_update_download_enforce.yaml
@@ -42,3 +42,8 @@ mobileconfig: true
 mobileconfig_info:
   com.apple.SoftwareUpdate:
     AutomaticDownload: true
+ddm_info:
+  declarationtype: com.apple.configuration.softwareupdate.settings
+  ddm_key: AutomaticActions
+  ddm_value:
+    Download: AlwaysOn


### PR DESCRIPTION
Add DDM support for software update rules (fixes #633)

Replaces deprecated `com.apple.SoftwareUpdate` payload usage by adding DDM (`com.apple.configuration.softwareupdate.settings`) equivalents where supported.

Added `ddm_info` blocks to:
- system_settings_software_update_download_enforce
- system_settings_install_macos_updates_enforce
- system_settings_critical_update_install_enforce

Existing `mobileconfig` blocks are retained for backward compatibility.

Some rules are unchanged due to lack of DDM support or scope limitations.