### PR TITLE
Fix: Add required EmailAccountType key to com.apple.mail.managed rules

### DIFF
--- a/rules/os/os_exchange_SMIME_encryption_certificate_overwrite_disable.yaml
+++ b/rules/os/os_exchange_SMIME_encryption_certificate_overwrite_disable.yaml
@@ -22,5 +22,6 @@ tags:
 supervised: false
 mobileconfig: true
 mobileconfig_info:
-  com.apple.mail.managed: 
+  com.apple.mail.managed:
+    EmailAccountType: EmailTypeIMAP
     SMIMEEncryptionCertificateUUIDUserOverrideable: false

--- a/rules/os/os_exchange_SMIME_encryption_default_certificate_overwrite_enable.yaml
+++ b/rules/os/os_exchange_SMIME_encryption_default_certificate_overwrite_enable.yaml
@@ -22,4 +22,5 @@ tags:
 mobileconfig: true
 mobileconfig_info:
   com.apple.mail.managed:
+    EmailAccountType: EmailTypeIMAP
     SMIMEEncryptByDefaultUserOverrideable: false

--- a/rules/os/os_exchange_SMIME_encryption_per_message_disable.yaml
+++ b/rules/os/os_exchange_SMIME_encryption_per_message_disable.yaml
@@ -5,7 +5,8 @@ discussion: |
 
   The user _MUST_ not be enabled to have the option to decide wether to encrypt a mail communication. Encryption _MUST_ be the default.
 check: " "
-fix: This is implemented by a Configuration Profile
+fix: |
+  This is implemented by a Configuration Profile.
 references:
   cce:
     - CCE-94528-7
@@ -21,5 +22,6 @@ tags:
 severity: "medium"
 mobileconfig: true
 mobileconfig_info:
-  com.apple.mail.managed: 
+  com.apple.mail.managed:
+    EmailAccountType: EmailTypeIMAP
     SMIMEEnableEncryptionPerMessageSwitch: false

--- a/rules/os/os_exchange_SMIME_signing_certificate_overwrite_disable.yaml
+++ b/rules/os/os_exchange_SMIME_signing_certificate_overwrite_disable.yaml
@@ -21,5 +21,6 @@ tags:
   - indigo_high
 mobileconfig: true
 mobileconfig_info:
-  com.apple.mail.managed: 
+  com.apple.mail.managed:
+    EmailAccountType: EmailTypeIMAP
     SMIMESigningCertificateUUIDUserOverrideable: false

--- a/rules/os/os_exchange_SMIME_signing_enabled.yaml
+++ b/rules/os/os_exchange_SMIME_signing_enabled.yaml
@@ -21,5 +21,6 @@ tags:
   - indigo_high
 mobileconfig: true
 mobileconfig_info:
-  com.apple.mail.managed: 
+  com.apple.mail.managed:
+    EmailAccountType: EmailTypeIMAP
     SMIMESigningEnabled: true

--- a/rules/os/os_exchange_SMIME_signing_overwrite_disable.yaml
+++ b/rules/os/os_exchange_SMIME_signing_overwrite_disable.yaml
@@ -21,5 +21,6 @@ tags:
   - indigo_high
 mobileconfig: true
 mobileconfig_info:
-  com.apple.mail.managed: 
+  com.apple.mail.managed:
+    EmailAccountType: EmailTypeIMAP
     SMIMESigningUserOverrideable: false

--- a/rules/os/os_exchange_mail_recents_sync_disable.yaml
+++ b/rules/os/os_exchange_mail_recents_sync_disable.yaml
@@ -23,4 +23,5 @@ supervised: false
 mobileconfig: true
 mobileconfig_info:
   com.apple.mail.managed:
+    EmailAccountType: EmailTypeIMAP
     disableMailRecentsSyncing: true

--- a/rules/os/os_exchange_peraccountVPN.yaml
+++ b/rules/os/os_exchange_peraccountVPN.yaml
@@ -26,5 +26,6 @@ tags:
 supervised: false
 mobileconfig: true
 mobileconfig_info:
-  com.apple.mail.managed: 
+  com.apple.mail.managed:
+    EmailAccountType: EmailTypeIMAP
     VPNUUID: $ODV

--- a/rules/os/os_exchange_prevent_move_enforce.yaml
+++ b/rules/os/os_exchange_prevent_move_enforce.yaml
@@ -23,5 +23,6 @@ tags:
 supervised: false
 mobileconfig: true
 mobileconfig_info:
-  com.apple.mail.managed: 
+  com.apple.mail.managed:
+    EmailAccountType: EmailTypeIMAP
     PreventMove: true

--- a/rules/os/os_mail_maildrop_disable.yaml
+++ b/rules/os/os_mail_maildrop_disable.yaml
@@ -51,4 +51,5 @@ supervised: false
 mobileconfig: true
 mobileconfig_info:
   com.apple.mail.managed:
+    EmailAccountType: EmailTypeIMAP
     allowMailDrop: false

--- a/rules/os/os_mail_move_messages_disable.yaml
+++ b/rules/os/os_mail_move_messages_disable.yaml
@@ -53,4 +53,5 @@ supervised: false
 mobileconfig: true
 mobileconfig_info:
   com.apple.mail.managed:
+    EmailAccountType: EmailTypeIMAP
     PreventMove: false


### PR DESCRIPTION
Resolves #481
All 11 rules using the `com.apple.mail.managed` payload domain were missing the `EmailAccountType` key, which Apple's device management spec marks as required. Without it, these profiles silently fail to deploy when pushed from an MDM server.

Added `EmailAccountType: EmailTypeIMAP` to all affected rules. IMAP is used as the account type since POP3 does not support S/MIME signing, encryption, or folder-level operations enforced by several of these rules.

Note: cspell CI failures will be resolved once PR #656 is merged into main, as it adds the required project-specific identifiers to project-words.txt.