### PR TITLE
fix: correct spelling typos in ios18 branch files

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Civilian agencies are to use the National Checklist Program as required by [NIST
 |John Mahlman IV|Leidos
 |Aaron Kegerreis|DISA
 |Henry Stamerjohann|Declarative IT GmbH
-|Marco A Piñeryo II|State Department
+|Marco A Piñeyro II|State Department
 |Jason Blake|NIST
 |Blair Heiserman|NIST
 |Joshua Glemza|NASA

--- a/rules/os/os_files_network_drive_access_disable.yaml
+++ b/rules/os/os_files_network_drive_access_disable.yaml
@@ -1,7 +1,7 @@
 id: os_files_network_drive_access_disable
 title: "Ensure Allow network drive access in Files app is set to Disabled"
 discussion: |
-  Network drive acces in Files app _MUST_ be disabled.
+  Network drive access in Files app _MUST_ be disabled.
 check: " "
 fix: |
   This is implemented by a Configuration Profile.

--- a/rules/supplemental/supplemental_cis_manual.yaml
+++ b/rules/supplemental/supplemental_cis_manual.yaml
@@ -140,7 +140,7 @@ discussion: |
   [cols="15%h, 85%a"]
   |===
   |Section
-  |Additional Reccomendations
+  |Additional Recommendations
 
   |Recommendations
   |4.1.1 Review Manage Sharing & Access +


### PR DESCRIPTION
- Fix "acces" -> "access" in os_files_network_drive_access_disable.yaml
- Fix "Reccomendations" -> "Recommendations" in supplemental_cis_manual.yaml
- Fix "Piñeryo" -> "Piñeyro" in README.md

Note: cspell CI failures will be resolved once PR https://github.com/usnistgov/macos_security/pull/656 is merged into main, as it adds the required project-specific identifiers to project-words.txt.