### PR TITLE
fix: add project-specific identifiers to cspell project-words.txt

### DIFF
--- a/.github/cspell/project-words.txt
+++ b/.github/cspell/project-words.txt
@@ -64,6 +64,7 @@ declarationtype
 deidentification
 desktopservices
 destroyfvkeyonstandby
+diable
 disa
 diskmanagement
 diskutil
@@ -168,6 +169,7 @@ osascript
 OSCP
 osxserver
 OTAPKI
+overwirte
 passwordauthentication
 passwordpolicy
 pathlist
@@ -195,6 +197,8 @@ pwpolicy
 pydantic
 pyyaml
 reauthentication
+recents
+Recents
 Remediator
 rootok
 rstrip
@@ -329,6 +333,7 @@ stigs
 STIGS
 sysprefs
 uchg
+unenrollment
 VALUEONDEMAND
 vared
 xccdfrules


### PR DESCRIPTION
The following words are flagged by cspell CI but cannot be changed 
as they are baked into existing rule IDs and filenames. Changing them 
would be a breaking change for anyone referencing these rule IDs.

- overwirte: exists in rule IDs os_exchange_SMIME_encryption_certificate_overwirte_disable 
  and os_exchange_SMIME_signing_certificate_overwirte_disable
- diable: exists in rule ID os_siri_assistant_diable
- recents/Recents: exists in rule ID os_exchange_mail_recents_sync_disable
- unenrollment: legitimate word used in DISA STIG supplemental text

Adding these to project-words.txt to silence cspell CI failures 
without making breaking changes to existing rule IDs.