### PR TITLE
Added Localization/language

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -127,6 +127,7 @@ head: [
 					items: [
 						{ label: 'Generate Mapping', link: '/other/generate-mapping/' },
 						{ label: 'Generate SCAP', link: '/other/generate-scap/' },
+						{ label: 'Generate Localization', link: '/other/generate-localization/' },
 					],
 				},
 				{

--- a/src/content/docs/guidance/how-to-generate-guidance.mdx
+++ b/src/content/docs/guidance/how-to-generate-guidance.mdx
@@ -231,6 +231,13 @@ mSCP 2.0 is under active development and should not be used in production. Pleas
 ./mscp.py guidance custom/baselines/800-53r5_moderate_macos_26.0.yaml -m
 ```
 
+**Generate documentation in a specific language:**
+```bash
+./mscp.py guidance custom/baselines/800-53r5_moderate_macos_26.0.yaml -L de
+```
+
+The default language is English (`en`). Available languages are determined by the locales present in `config/locales/`. See <a href={`${base}other/generate-localization/`}>Generate Localization</a> for how to create and compile translation files.
+
   </TabItem>
   <TabItem label="mSCP 1.0">
 

--- a/src/content/docs/other/generate-localization.mdx
+++ b/src/content/docs/other/generate-localization.mdx
@@ -1,0 +1,130 @@
+---
+title: Generate Localization
+description: Create and compile translation files to generate guidance in other languages.
+---
+
+import { Steps, FileTree, Aside, Tabs, TabItem } from '@astrojs/starlight/components';
+
+export const base = import.meta.env.BASE_URL.endsWith('/') ? import.meta.env.BASE_URL : import.meta.env.BASE_URL + '/';
+
+The localization workflow lets you generate guidance documents in languages other than English. It involves generating a JSON template of translatable strings, translating them, and compiling the result into a format the tool can use.
+
+<Aside type="note">
+Localization is only available in mSCP 2.0.
+</Aside>
+
+---
+
+## Overview
+
+<Steps>
+
+1. **Generate a translation template**
+
+   Extract all translatable strings into a JSON file:
+
+   ```bash
+   ./mscp.py admin translation-json
+   ```
+
+   This creates `messages.json` in the `build/` output directory.
+
+2. **Translate the strings**
+
+   Open `messages.json` and fill in the translated values for each string.
+
+3. **Compile to a `.mo` file**
+
+   Convert the translated JSON into a binary format:
+
+   ```bash
+   ./mscp.py admin mo-from-json build/messages.json -l de
+   ```
+
+   This creates `build/locale/de/LC_MESSAGES/messages.mo`.
+
+4. **Generate guidance in your language**
+
+   ```bash
+   ./mscp.py guidance custom/baselines/800-53r5_moderate_macos_26.0.yaml -L de
+   ```
+
+</Steps>
+
+---
+
+## Command Reference
+
+### Generate Translation Template
+
+```bash
+./mscp.py admin translation-json [OPTIONS]
+```
+
+| Flag | Description |
+|:-----|:------------|
+| `-o OUTPUT` | Output file path (default: `messages.json`) |
+| `-d DOMAIN` | Translation domain (default: `messages`) |
+
+**Example — custom output path:**
+```bash
+./mscp.py admin translation-json -o ~/Desktop/translations.json
+```
+
+---
+
+### Compile Translations to MO
+
+```bash
+./mscp.py admin mo-from-json JSON_FILE [OPTIONS]
+```
+
+| Flag | Description |
+|:-----|:------------|
+| `JSON_FILE` | Path to the translated JSON file (required) |
+| `-l LOCALE` | Target locale code, e.g. `de`, `fr`, `ja` (required) |
+| `-m MO_FILE` | Output `.mo` filename (default: `messages.mo`) |
+| `-d DOMAIN` | Translation domain (default: `messages`) |
+| `-f` | Enable fuzzy translation matching |
+
+**Example — compile German translations:**
+```bash
+./mscp.py admin mo-from-json build/messages.json -l de
+```
+
+The compiled file is placed at `build/locale/{LOCALE}/LC_MESSAGES/messages.mo`.
+
+---
+
+## Output Structure
+
+<FileTree>
+- build/
+    - messages.json Translation template
+    - locale/
+        - de/
+            - LC_MESSAGES/
+                - **messages.mo** Compiled translation
+                - **messages.po** Human-readable translation source
+</FileTree>
+
+---
+
+## Next Steps
+
+- <a href={`${base}guidance/how-to-generate-guidance/`}>How to Generate Guidance</a> — Use `-L LANG` to generate in your language
+
+<style>{`
+  .sl-markdown-content th {
+    background: var(--sl-color-accent-low);
+    font-weight: 600;
+  }
+  .sl-markdown-content td, .sl-markdown-content th {
+    padding: 0.6rem 1rem;
+  }
+  .sl-markdown-content td code {
+    background: var(--sl-color-bg-inline-code);
+    padding: 0.15em 0.35em;
+    font-size: 0.85em;
+  }
+`}</style>

--- a/src/content/docs/repository/script-arguments-list.mdx
+++ b/src/content/docs/repository/script-arguments-list.mdx
@@ -101,6 +101,39 @@ Creates custom rules and baselines for unsupported compliance frameworks.
 | `-c CSV, --csv CSV` | Path to CSV mapping file (required) |
 | `-f FRAMEWORK, --framework FRAMEWORK` | Source framework to map from (default: `800-53r5`) |
 
+---
+
+### mscp.py admin translation-json
+
+Extracts all translatable strings into a JSON template file.
+
+```bash
+./mscp.py admin translation-json [OPTIONS]
+```
+
+| Argument | Description |
+|:---------|:------------|
+| `-o OUTPUT, --output OUTPUT` | Output file path (default: `messages.json`) |
+| `-d DOMAIN, --domain DOMAIN` | Translation domain (default: `messages`) |
+
+---
+
+### mscp.py admin mo-from-json
+
+Compiles a translated JSON file into a binary `.mo` file for use with gettext.
+
+```bash
+./mscp.py admin mo-from-json JSON_FILE [OPTIONS]
+```
+
+| Argument | Description |
+|:---------|:------------|
+| `JSON_FILE` | Path to the translated JSON file (required) |
+| `-l LOCALE, --locale LOCALE` | Target locale code, e.g. `de`, `fr` (required) |
+| `-m MO_FILE, --mo_file MO_FILE` | Output `.mo` filename (default: `messages.mo`) |
+| `-d DOMAIN, --domain DOMAIN` | Translation domain (default: `messages`) |
+| `-f, --use_fuzzy` | Enable fuzzy translation matching |
+
   </TabItem>
   <TabItem label="mSCP 1.0">
 


### PR DESCRIPTION
 ## Documentation & Site Improvements

## Localization/language                                                                                                                                            
                                                                                                                                                          
  - Added instructions for generating guidance in a different language using the `-L` flag                                                                
  - Added a new **Generate Localization** page explaining how to create and compile translation files                                                     
  - Added `admin translation-json` and `admin mo-from-json` commands to the script arguments reference  