### PR TITLE
cspell.json: remove trailing comma

### DIFF
--- a/.github/cspell/cspell.json
+++ b/.github/cspell/cspell.json
@@ -22,5 +22,5 @@
         "path": "./project-names.txt",
         "addWords": true
     }
-  ],
+  ]
 }


### PR DESCRIPTION
This trailing comma may prevent some tools from parsing this JSON file or validating its syntax.