### PR TITLE
NIST Pages Update

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -144,3 +144,15 @@ if (image) {
 		}
 	}
 </style>
+
+<style is:global>
+	.hero-platform {
+		font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+		font-weight: 700;
+	}
+
+	.hero-project {
+		font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+		font-weight: 400;
+	}
+</style>

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -5,6 +5,7 @@ template: splash
 editUrl: false
 lastUpdated: false
 hero:
+  title: '<span class="hero-platform">macOS</span> <span class="hero-project">Security Compliance Project</span>'
   tagline: "Open source Apple OS security guidance (macOS, iOS/iPadOS, visionOS)—built by government and industry experts, based on <a href='https://csrc.nist.gov/pubs/sp/800/53/r5/upd1/final'>NIST SP 800-53</a>, authoritative per <a href='https://csrc.nist.gov/pubs/sp/800/219/r1/final'>SP 800-219</a> and <a href='https://csrc.nist.gov/pubs/sp/800/70/r5/ipd'>800-70</a>, with baselines and benchmarks for government, industry, and international use. <a href='https://support.apple.com/guide/certifications/macos-security-compliance-project-apc322685bb2/web'>Recognized by Apple</a>."
   image:
     file: ../../assets/logo.png

--- a/src/content/docs/mscp-2/overview.mdx
+++ b/src/content/docs/mscp-2/overview.mdx
@@ -167,7 +167,7 @@ The easiest way to get started — no local dependencies required.
    container run -it \
      --volume ~/Desktop/mscp:/mscp/build \
      --volume ~/Desktop/mscp/custom:/mscp/custom \
-     ghcr.io/usnistgov/macos_security:latest
+     ghcr.io/usnistgov/mscp_2.0:latest
    ```
 
    <details>
@@ -201,7 +201,7 @@ The easiest way to get started — no local dependencies required.
    docker run -it \
      --volume /Users/<username>/Desktop/mscp:/mscp/build \
      --volume /Users/<username>/Desktop/mscp/custom:/mscp/custom \
-     ghcr.io/usnistgov/macos_security:latest
+     ghcr.io/usnistgov/mscp_2.0:latest
    ```
 
 3. ### Generate Content
@@ -225,7 +225,7 @@ The easiest way to get started — no local dependencies required.
 Manual setup with virtual environment.
 
 **Requirements:**
-- Python >= 3.14
+- Python >= 3.12
   - Recommended: [Macadmins Python](https://github.com/macadmins/python)
 - Ruby >= 3.4.4
 

--- a/src/content/docs/repository/script-arguments-list.mdx
+++ b/src/content/docs/repository/script-arguments-list.mdx
@@ -37,6 +37,7 @@ Generates documentation, configuration profiles, compliance scripts, and DDM com
 | `--granular-profiles` | Generate granular per-setting profiles |
 | `-d, --ddm` | Generate DDM components |
 | `-x, --xlsx` | Generate Excel spreadsheet |
+| `-M, --manifest` | Generate a JSON manifest file for the rules in the baseline |
 | `-m, --markdown` | Generate Markdown documentation |
 | `-l LOGO, --logo LOGO` | Path to logo file for the guide |
 | `-L LANG, --language LANG` | Language for output |

--- a/src/content/docs/welcome/getting-started.mdx
+++ b/src/content/docs/welcome/getting-started.mdx
@@ -50,7 +50,7 @@ mSCP 2.0 is under active development and should not be used in production. Pleas
    container run -it \
      --volume ~/Desktop/mscp:/mscp/build \
      --volume ~/Desktop/mscp/custom:/mscp/custom \
-     ghcr.io/usnistgov/macos_security:latest
+     ghcr.io/usnistgov/mscp_2.0:latest
    ```
 
    <details>
@@ -84,7 +84,7 @@ mSCP 2.0 is under active development and should not be used in production. Pleas
    docker run -it \
      --volume /Users/<username>/Desktop/mscp:/mscp/build \
      --volume /Users/<username>/Desktop/mscp/custom:/mscp/custom \
-     ghcr.io/usnistgov/macos_security:latest
+     ghcr.io/usnistgov/mscp_2.0:latest
    ```
 
 3. **Generate Content**
@@ -107,7 +107,7 @@ mSCP 2.0 is under active development and should not be used in production. Pleas
 Manual setup with Python and Ruby.
 
 **Requirements:**
-- Python >= 3.14
+- Python >= 3.12
   - Recommended: [Macadmins Python](https://github.com/macadmins/python)
 - Ruby >= 3.4.4
 

--- a/src/content/docs/welcome/quick-guide.mdx
+++ b/src/content/docs/welcome/quick-guide.mdx
@@ -89,7 +89,7 @@ Prefer to install manually with Python and Ruby? See the <a href={`${base}welcom
    container run -it \
      --volume ~/Desktop/mscp:/mscp/build \
      --volume ~/Desktop/mscp/custom:/mscp/custom \
-     ghcr.io/usnistgov/macos_security:latest
+     ghcr.io/usnistgov/mscp_2.0:latest
    ```
 
    <details>
@@ -123,7 +123,7 @@ Prefer to install manually with Python and Ruby? See the <a href={`${base}welcom
    docker run -it \
      --volume /Users/<username>/Desktop/mscp:/mscp/build \
      --volume /Users/<username>/Desktop/mscp/custom:/mscp/custom \
-     ghcr.io/usnistgov/macos_security:latest
+     ghcr.io/usnistgov/mscp_2.0:latest
    ```
 
 3. **Generate a Baseline**


### PR DESCRIPTION
## Documentation Updates 

  - **Fixed Python version requirement** — The docs incorrectly said Python 3.14 was required for mSCP 2.0. It actually requires Python 3.12 or newer.
                                                                                                                                                                                                                                                                                            
  - **Fixed container image name** — The docs were pointing to the wrong container image. Updated to the correct mSCP 2.0 image (`ghcr.io/usnistgov/mscp_2.0:latest`) in all places.
                                                                                                                                                                                                                                                                                            
  - **Added missing command option** — The `--manifest` flag was missing from the script arguments reference page. This option generates a JSON manifest file and is part of the `guidance` command.                                                                                                                                                                                                                                                                 
                                                            
  - **Fixed homepage font styling** — Applied correct fonts to the hero title on the homepage. "macOS" now displays in bold and "Security Compliance Project" in regular weight, both using Helvetica Neue.  