### PR TITLE
Update os_sleep_and_display_sleep_apple_silicon_enable

### DIFF
--- a/rules/os/os_sleep_and_display_sleep_apple_silicon_enable.yaml
+++ b/rules/os/os_sleep_and_display_sleep_apple_silicon_enable.yaml
@@ -4,7 +4,7 @@ discussion: |
   Apple Silicon MacBooks should set sleep timeout to 15 minutes (900 seconds) or less and the display sleep timeout should be 10 minutes (600 seconds) or less but less than the sleep setting.
 check: |
   error_count=0
-  if /usr/sbin/system_profiler SPHardwareDataType 2>/dev/null  | /usr/bin/grep -Ei "MacBook|Mac[0-9]" 2>/dev/null ; then
+  if /usr/sbin/system_profiler SPHardwareDataType 2>/dev/null  | /usr/bin/grep -Ei "MacBook|Mac[0-9]" /dev/null ; then
     cpuType=$(/usr/sbin/sysctl -n machdep.cpu.brand_string)
     if echo "$cpuType" | grep -q "Apple"; then
       sleepMode=$(/usr/bin/pmset -b -g | /usr/bin/grep '^\s*sleep' 2>&1 | /usr/bin/awk '{print $2}')

--- a/rules/os/os_sleep_and_display_sleep_apple_silicon_enable.yaml
+++ b/rules/os/os_sleep_and_display_sleep_apple_silicon_enable.yaml
@@ -4,7 +4,7 @@ discussion: |
   Apple Silicon MacBooks should set sleep timeout to 15 minutes (900 seconds) or less and the display sleep timeout should be 10 minutes (600 seconds) or less but less than the sleep setting.
 check: |
   error_count=0
-  if /usr/sbin/system_profiler SPHardwareDataType | /usr/bin/grep -Ei "MacBook|Mac[0-9]"; then
+  if /usr/sbin/system_profiler SPHardwareDataType 2>/dev/null  | /usr/bin/grep -Ei "MacBook|Mac[0-9]" 2>/dev/null ; then
     cpuType=$(/usr/sbin/sysctl -n machdep.cpu.brand_string)
     if echo "$cpuType" | grep -q "Apple"; then
       sleepMode=$(/usr/bin/pmset -b -g | /usr/bin/grep '^\s*sleep' 2>&1 | /usr/bin/awk '{print $2}')


### PR DESCRIPTION
It looks like when this moved from `ioreg` to `system_profiler`, extra output ended up in the result which causes false-negative failures e.g.,
```
Mon May  4 14:09:42 UTC 2026 os_sleep_and_display_sleep_apple_silicon_enable failed (Result:       Model Name: MacBook Pro
      Model Identifier: MacBookPro18,1
0, Expected: "{'integer': 0}")
```
This just redirects that output to `/dev/null` to ensure a clean result.

Note: I included stderr to `/dev/null` for system_profiler just because when running the check outside of the script I was seeing output like `2026-05-04 10:49:38.285 system_profiler[93002:25784279] hw.cpufamily: 0x5f4dea93`. I don't think the resulting check script created by the build actually displays that, but figured might as well keep it fully clean.