### PR TITLE
Add python cooldown

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,18 @@ Source = "https://github.com/usnistgov/macos_security"
 [project.scripts]
 mscp = "mscp.__main__:main"
 
+[tool.uv]
+# Dependency cooldown: the resolver ignores any release published less than a
+# week ago, so `uv lock` / `uv add` / `uv sync` won't adopt a brand-new (and
+# possibly compromised) version. Mirrors the 7-day cooldown in .renovaterc.json5.
+# Accepts a friendly duration ("1 week"), ISO 8601 ("P7D"), or an RFC 3339 date.
+# NOTE: this also delays security fixes — pair with an independent scanner.
+exclude-newer = "1 week"
+# Escape hatch: opt a single package OUT of the cooldown when you need a fix
+# immediately, e.g.  exclude-newer-package = { some-package = false }
+# Remove the override once the cooldown is acceptable for that package again.
+# exclude-newer-package = {}
+
 [tool.hatch.version]
 path = "src/mscp/__init__.py"
 


### PR DESCRIPTION
Don’t adopt any dependency release until it's been public for 7+ days.
This is a good countermeasure to supply chain attacks.