### PR TITLE
Refactor baseline accessors and improve documentation processing

### DIFF
--- a/custom/.gitignore
+++ b/custom/.gitignore
@@ -1,1 +1,10 @@
 **/*.y*ml
+**/*.jinja
+**/*.css
+**/*.*o
+**/*.sh
+**/*.xml
+**/*.json
+**/*.md
+**/*.mobileconfig
+**/*.png

--- a/src/mscp/__main__.py
+++ b/src/mscp/__main__.py
@@ -8,18 +8,17 @@ exist, then delegates to `parse_cli`.
 import sys
 
 from .cli import parse_cli
-from .common_utils import logger, ensure_custom_dirs
+from .common_utils import logger
 
 
 def main() -> None:
     """Run the mSCP CLI as a module entry point.
 
-    Enables the `mscp` loguru logger, calls `ensure_custom_dirs` to create
-    the per-user custom directories on first run, then dispatches to
-    `parse_cli`.
+    Enables the `mscp` loguru logger then delegates to `parse_cli`, which
+    calls `set_custom_dir` (if ``--custom_dir`` was supplied) and
+    `ensure_custom_dirs` before dispatching to the appropriate sub-command.
     """
     logger.enable("mscp")
-    ensure_custom_dirs()
     parse_cli()
 
 

--- a/src/mscp/classes/__init__.py
+++ b/src/mscp/classes/__init__.py
@@ -11,6 +11,7 @@ Re-exports the public model classes used throughout mSCP:
 """
 
 from .baseline import Author, Baseline, Profile
+from .legacy_baseline import LegacyBaseline, LegacyProfile
 
 # from .filehandler import FileHandler
 from .macsecurityrule import Macsecurityrule, Sectionmap
@@ -19,6 +20,8 @@ from .rule_library import RuleLibrary
 
 __all__ = [
     "Baseline",
+    "LegacyBaseline",
+    "LegacyProfile",
     "Macsecurityrule",
     "Payload",
     "Author",

--- a/src/mscp/classes/_base.py
+++ b/src/mscp/classes/_base.py
@@ -1,0 +1,51 @@
+# mscp/classes/_base.py
+"""Shared Pydantic base class with dict-style accessors.
+
+A single definition consumed by both `baseline` and `macsecurityrule` to
+avoid duplication and keep behavior consistent.
+"""
+
+from typing import Any
+
+from pydantic import BaseModel
+
+__all__ = ["BaseModelWithAccessors"]
+
+
+class BaseModelWithAccessors(BaseModel):
+    """Pydantic base class with dict-style accessors.
+
+    Adds `get` plus ``__getitem__`` / ``__setitem__`` so subclasses can be
+    treated either as Pydantic models or as plain dict-like objects.
+    Item access delegates to ``getattr`` / ``setattr``, so any attribute
+    that exists on the instance (declared field or dynamic) is reachable.
+    Unknown keys raise ``KeyError`` rather than silently creating new
+    attributes.
+    """
+
+    def get(self, attr: str, default: Any = None) -> Any:
+        """Return the value of *attr*, or *default* if it is absent.
+
+        Args:
+            attr: Attribute name to read.
+            default: Value returned when *attr* is absent. Defaults to
+                ``None``.
+
+        Returns:
+            The attribute value, or *default* if no such attribute exists.
+        """
+        return getattr(self, attr, default)
+
+    def __getitem__(self, key: str) -> Any:
+        """Dict-style read; raises ``KeyError`` if the attribute is missing."""
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError(key) from None
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        """Dict-style write; raises ``KeyError`` if the attribute is forbidden."""
+        try:
+            setattr(self, key, value)
+        except AttributeError:
+            raise KeyError(f"{key!r} is not a valid attribute") from None

--- a/src/mscp/classes/baseline.py
+++ b/src/mscp/classes/baseline.py
@@ -18,7 +18,7 @@ import pandas as pd
 from pydantic import BaseModel
 
 # Local python modules
-from ..common_utils import config, create_yaml, open_file
+from ..common_utils import config, create_yaml, open_file, search_paths
 from ..common_utils.logger_instance import logger
 from .macsecurityrule import Macsecurityrule
 
@@ -122,22 +122,19 @@ class Baseline(BaseModel):
         cls,
         file_path: Path,
         language: str = "en",
-        custom: bool = False,
     ) -> "Baseline":
         """Load a `Baseline` from a YAML file with rules resolved.
 
         Reads the baseline document, then for each profile entry resolves
-        the matching section file (under ``config["sections_dir"]``, plus
-        ``config["custom"]["sections_dir"]`` if `custom` is set) and
-        loads its rules via `Macsecurityrule.load_rules`.
+        the matching section file.  The custom sections directory (from
+        ``config["custom"]["sections_dir"]``) is always searched first so
+        that user-provided section files shadow the bundled defaults on a
+        per-file basis.
 
         Args:
             file_path (Path): Path to the baseline YAML file.
             language (str): Language code passed through to the file
                 loader for localised strings. Defaults to ``"en"``.
-            custom (bool): If true, also search the configured custom
-                sections directory when resolving section files.
-                Defaults to ``False``.
 
         Returns:
             Baseline: A fully populated baseline with all profiles and
@@ -147,15 +144,7 @@ class Baseline(BaseModel):
 
         logger.info(f"Attempting to open Baseline file: {file_path}")
 
-        section_dirs: list[Path] = []
-
-        if custom:
-            section_dirs = [
-                Path(config["custom"]["sections_dir"]),
-                Path(config["sections_dir"]),
-            ]
-        else:
-            section_dirs = [Path(config["sections_dir"])]
+        section_dirs: list[Path] = [Path(p) for p in search_paths("sections_dir")]
 
         baseline_data: dict[str, Any] = open_file(file_path, language)
         authors = [Author(**author) for author in baseline_data.get("authors", [])]

--- a/src/mscp/classes/baseline.py
+++ b/src/mscp/classes/baseline.py
@@ -11,7 +11,7 @@ methods to load baselines from YAML and write them back out.
 # Standard python modules
 from collections import OrderedDict, defaultdict
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, ClassVar, Optional
 
 # Additional python modules
 import pandas as pd
@@ -25,76 +25,24 @@ from .macsecurityrule import Macsecurityrule
 __all__ = ["Author", "Profile", "Baseline"]
 
 
-class BaseModelWithAccessors(BaseModel):
-    """Pydantic base class with dict-style accessors.
-
-    Adds `get` plus ``__getitem__`` / ``__setitem__`` so subclasses can be
-    treated either as Pydantic models or as plain dict-like objects. Item
-    access is restricted to declared model fields to keep typos from
-    silently creating new attributes.
-    """
-
-    def get(self, attr: str, default: Any = None) -> Any:
-        """Return the value of `attr`, or `default` if it isn't set.
-
-        Unlike ``__getitem__``, this never raises and is not restricted to
-        declared model fields — it just delegates to `getattr`.
-
-        Args:
-            attr (str): Attribute name to read.
-            default (Any): Value returned when ``attr`` is absent.
-                Defaults to ``None``.
-
-        Returns:
-            Any: The attribute value, or ``default`` if no such attribute
-                exists on the instance.
-        """
-        return getattr(self, attr, default)
-
-    def __getitem__(self, key: str) -> Any:
-        """Dict-style read of a declared model field.
-
-        Raises:
-            KeyError: If ``key`` is not a declared field on the class.
-        """
-        if key in self.__class__.model_fields:
-            return getattr(self, key)
-        raise KeyError(f"{key} is not a valid attribute of {self.__class__.__name__}")
-
-    def __setitem__(self, key: str, value: Any) -> None:
-        """Dict-style write to a declared model field.
-
-        Raises:
-            KeyError: If ``key`` is not a declared field on the class.
-        """
-        if key in self.__class__.model_fields:
-            setattr(self, key, value)
-        else:
-            raise KeyError(
-                f"{key} is not a valid attribute of {self.__class__.__name__}"
-            )
-
-
-class Author(BaseModelWithAccessors):
+class Author(BaseModel):
     """One author or owning organization of a baseline.
 
     Attributes:
         name (str | None): Personal name of the author, if available.
         organization (str | None): Organization the author represents, if
             applicable.
+        additional (bool | None): True when this author is in addition to
+            the primary MSCP contributors.
     """
 
     name: str | None
     organization: str | None
     additional: Optional[bool] = None
 
+    @property
     def is_additional(self) -> bool:
-        """Return true if this author is in addition to MSCP contributors.
-
-        This is a simple helper that checks the `additional` field, which
-        should be set to true for any author that is not a primary contributor
-        to MSCP. This allows generated guidance to flag such authors
-        and their contributions for special attention.
+        """True if this author is in addition to the primary MSCP contributors.
 
         Returns:
             bool: True when `additional` is true, false otherwise.
@@ -102,7 +50,7 @@ class Author(BaseModelWithAccessors):
         return self.additional is True
 
 
-class Profile(BaseModelWithAccessors):
+class Profile(BaseModel):
     """A named section of a baseline grouping related rules.
 
     Profiles correspond to the top-level groupings rendered in generated
@@ -124,7 +72,7 @@ class Profile(BaseModelWithAccessors):
     rules: list[Macsecurityrule]
 
 
-class Baseline(BaseModelWithAccessors):
+class Baseline(BaseModel):
     """An mSCP baseline document.
 
     A baseline pairs metadata about a security guide (title, description,
@@ -146,6 +94,20 @@ class Baseline(BaseModelWithAccessors):
         parent_values (str): Name of the parent benchmark this baseline
             inherits from (e.g. ``"recommended"``), or empty.
     """
+
+    #: Canonical section order used by `to_yaml`.
+    _PROFILE_ORDER: ClassVar[list[str]] = [
+        "Auditing",
+        "Authentication",
+        "iCloud",
+        "Operating System",
+        "Password Policy",
+        "System Settings",
+        "Inherent",
+        "Permanent",
+        "Not Applicable",
+        "Supplemental",
+    ]
 
     authors: list[Author]
     profile: list[Profile]
@@ -187,7 +149,6 @@ class Baseline(BaseModelWithAccessors):
 
         section_dirs: list[Path] = []
 
-        # section_dir: Path = Path(config["sections_dir"])
         if custom:
             section_dirs = [
                 Path(config["custom"]["sections_dir"]),
@@ -267,7 +228,7 @@ class Baseline(BaseModelWithAccessors):
         os_version: float,
         baseline_dict: dict[str, Any],
         language: str = "en",
-    ) -> None:
+    ) -> "Baseline":
         """Build a new baseline from a rule set and write it to YAML.
 
         Groups ``rules`` into profiles by their `section` (or by special
@@ -296,6 +257,9 @@ class Baseline(BaseModelWithAccessors):
             language (str): Language code for loaded section descriptions.
                 Defaults to ``"en"``.
 
+        Returns:
+            Baseline: The newly constructed and written baseline.
+
         Side Effects:
             Writes the generated baseline to ``output_file``. Reads every
             ``*.y*ml`` file in ``config["sections_dir"]`` to resolve
@@ -304,20 +268,29 @@ class Baseline(BaseModelWithAccessors):
 
         description: str = ""
         os_type = os_type.replace("os", "OS")
-        # custom_output_file: Path = Path(
-        #     config["custom"]["baseline_dir"], output_file.name
-        # )
 
         if "title" not in baseline_dict:
             baseline_dict["title"] = (
-                f"{os_type} {os_version}: Security Configuration - {f'{full_title}' if full_title else ''}{f'{baseline_name}' if baseline_name else ''}"
+                f"{os_type} {os_version}: Security Configuration - "
+                f"{full_title if full_title else ''}{baseline_name if baseline_name else ''}"
             )
 
         if "description" not in baseline_dict:
-            description: str = f"This guide describes the actions to take when securing a {os_type} {os_version} system against the {f'{full_title}' if full_title else ''}{f'{baseline_name}' if baseline_name else ''} security benchmark.\n"
+            description = (
+                f"This guide describes the actions to take when securing a "
+                f"{os_type} {os_version} system against the "
+                f"{full_title if full_title else ''}{baseline_name if baseline_name else ''} "
+                f"security benchmark.\n"
+            )
 
             if benchmark == "recommended":
-                description += "\nInformation System Security Officers and benchmark creators can use this catalog of settings in order to assist them in security benchmark creation. This list is a catalog, not a checklist or benchmark, and satisfaction of every item is not likely to be possible or sensible in many operational scenarios."
+                description += (
+                    "\nInformation System Security Officers and benchmark creators "
+                    "can use this catalog of settings in order to assist them in "
+                    "security benchmark creation. This list is a catalog, not a "
+                    "checklist or benchmark, and satisfaction of every item is not "
+                    "likely to be possible or sensible in many operational scenarios."
+                )
 
         baseline_dict["description"] = description.strip()
 
@@ -328,12 +301,11 @@ class Baseline(BaseModelWithAccessors):
             "supplemental": "Supplemental",
         }
 
-        grouped_rules = defaultdict(list)
-        section_descriptions = {}
+        grouped_rules: defaultdict[str, list[Macsecurityrule]] = defaultdict(list)
+        section_descriptions: dict[str, str] = {}
 
         for yaml_file in Path(config["sections_dir"]).glob("*.y*ml"):
             section_data: dict = open_file(yaml_file, language)
-
             section_descriptions[section_data.get("name")] = section_data.get(
                 "description", ""
             )
@@ -375,7 +347,7 @@ class Baseline(BaseModelWithAccessors):
         )
 
         baseline.to_yaml(output_path=output_file)
-        # baseline.to_yaml(output_path=custom_output_file)
+        return baseline
 
     def to_dataframe(self) -> pd.DataFrame:
         """Flatten the baseline's rules into a `pandas.DataFrame`.
@@ -408,10 +380,8 @@ class Baseline(BaseModelWithAccessors):
         The serialised document orders top-level keys as ``title``,
         ``description``, ``authors``, ``parent_values``, ``platform``,
         ``profile`` (any other keys are dropped), and orders profiles by
-        a fixed sequence (``Auditing``, ``Authentication``, ``iCloud``,
-        ``Operating System``, ``Password Policy``, ``System Settings``,
-        followed by the special sections). Within each profile, ``rules``
-        is reduced to a sorted list of rule IDs.
+        `_PROFILE_ORDER` (unknown sections sort to the end). Within each
+        profile, ``rules`` is reduced to a sorted list of rule IDs.
 
         Args:
             output_path (Path): Destination YAML file.
@@ -427,18 +397,6 @@ class Baseline(BaseModelWithAccessors):
             "platform",
             "profile",
         ]
-        profile_order: list[str] = [
-            "Auditing",
-            "Authentication",
-            "iCloud",
-            "Operating System",
-            "Password Policy",
-            "System Settings",
-            "Inherent",
-            "Permanent",
-            "Not Applicable",
-            "Supplemental",
-        ]
         ordered_data: OrderedDict = OrderedDict()
 
         serialized_data.pop("name")
@@ -449,9 +407,9 @@ class Baseline(BaseModelWithAccessors):
         ordered_profiles = sorted(
             serialized_data["profile"],
             key=lambda p: (
-                profile_order.index(p["section"])
-                if p["section"] in profile_order
-                else len(profile_order)
+                self._PROFILE_ORDER.index(p["section"])
+                if p["section"] in self._PROFILE_ORDER
+                else len(self._PROFILE_ORDER)
             ),
         )
 

--- a/src/mscp/classes/baseline.py
+++ b/src/mscp/classes/baseline.py
@@ -292,7 +292,7 @@ class Baseline(BaseModel):
                     "likely to be possible or sensible in many operational scenarios."
                 )
 
-        baseline_dict["description"] = description.strip()
+            baseline_dict["description"] = description.strip()
 
         special_sections: dict[str, str] = {
             "inherent": "Inherent",

--- a/src/mscp/classes/legacy_baseline.py
+++ b/src/mscp/classes/legacy_baseline.py
@@ -1,0 +1,368 @@
+# mscp/classes/legacy_baseline.py
+"""Legacy baseline format support and migration to the current format.
+
+Pre-2.0 mSCP baseline YAML files differ from the current format in three ways:
+
+1. **authors** is a raw multiline AsciiDoc string (not a list of dicts).
+2. **platform** is absent (the OS name and version are embedded in the title).
+3. Profile **section** names are lowercase stems (``"auditing"``, ``"macos"``,
+   …) rather than canonical display names, and section grouping may reflect
+   an older version of the rule library.
+
+Rather than attempting to map old section names to new ones, migration
+re-resolves every rule ID against the *current* rule library for the target
+platform.  Each found rule carries its up-to-date section assignment, so the
+resulting baseline reflects the current structure.  Rule IDs that no longer
+exist in the library are reported but do not abort the migration.
+
+Typical usage::
+
+    from mscp.classes.legacy_baseline import LegacyBaseline
+
+    if LegacyBaseline.is_legacy(path):
+        lb = LegacyBaseline.from_yaml(path)
+        # platform is inferred from the title; pass platform= explicitly
+        # if inference fails (e.g. non-standard title format).
+        missing = lb.migrate(output_path)
+        if missing:
+            print("Rules not found in current library:", missing)
+"""
+
+# Standard python modules
+import re
+from pathlib import Path
+from typing import Any
+
+# Additional python modules
+from pydantic import BaseModel
+
+# Local python modules
+from ..common_utils import open_file
+from ..common_utils.logger_instance import logger
+from .baseline import Author, Baseline
+from .macsecurityrule import Macsecurityrule
+
+__all__ = ["LegacyBaseline", "LegacyProfile"]
+
+# Matches the OS family and version number embedded in a baseline title,
+# e.g. "macOS 26.0", "iOS 17.0", "visionOS 2.0".
+_PLATFORM_RE = re.compile(
+    r"\b(macOS|iOS|iPadOS|visionOS)\s+(\d+(?:\.\d+)*)\b"
+)
+
+
+class LegacyProfile(BaseModel):
+    """A profile section as stored in the legacy format.
+
+    Unlike the current `Profile`, rules are kept as plain strings (rule IDs)
+    rather than loaded `Macsecurityrule` objects.
+
+    Attributes:
+        section (str): Raw section name from the legacy YAML.
+        rules (list[str]): Rule IDs in the order they appear in the file.
+    """
+
+    section: str
+    rules: list[str]
+
+
+class LegacyBaseline(BaseModel):
+    """Parser and migrator for pre-2.0 mSCP baseline YAML files.
+
+    Attributes:
+        title (str): Full title string, used to infer the target platform.
+        description (str): Baseline description text.
+        authors (str): Raw AsciiDoc authors block.
+        parent_values (str): Parent benchmark identifier.
+        profile (list[LegacyProfile]): Profile sections with rule-ID lists.
+    """
+
+    title: str
+    description: str = ""
+    authors: str
+    parent_values: str = ""
+    profile: list[LegacyProfile]
+
+    # ------------------------------------------------------------------
+    # Construction / detection
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def is_legacy(cls, file_path: Path) -> bool:
+        """Return ``True`` if *file_path* looks like a pre-2.0 baseline.
+
+        The primary indicator is an ``authors`` value that is a plain string
+        rather than a list of dicts.  A missing ``platform`` key is treated as
+        a secondary indicator.
+
+        Args:
+            file_path (Path): Path to the baseline YAML to inspect.
+
+        Returns:
+            bool: ``True`` when the file appears to be in legacy format.
+        """
+        data: dict[str, Any] = open_file(file_path)
+        return isinstance(data.get("authors"), str) or "platform" not in data
+
+    @classmethod
+    def from_yaml(cls, file_path: Path) -> "LegacyBaseline":
+        """Load a legacy baseline YAML file.
+
+        Args:
+            file_path (Path): Path to the legacy baseline YAML.
+
+        Returns:
+            LegacyBaseline: The parsed legacy baseline.
+
+        Raises:
+            ValueError: If the file does not appear to be in legacy format.
+                Use `Baseline.from_yaml` for current-format files.
+        """
+        data: dict[str, Any] = open_file(file_path)
+
+        if not cls.is_legacy(file_path):
+            raise ValueError(
+                f"{file_path} does not appear to be a legacy baseline "
+                "(authors is already a list and platform is present). "
+                "Use Baseline.from_yaml() instead."
+            )
+
+        return cls(
+            title=data.get("title", ""),
+            description=data.get("description", ""),
+            authors=data.get("authors", ""),
+            parent_values=data.get("parent_values", ""),
+            profile=[LegacyProfile(**p) for p in data.get("profile", [])],
+        )
+
+    # ------------------------------------------------------------------
+    # Parsing helpers
+    # ------------------------------------------------------------------
+
+    def parse_authors(self) -> list[Author]:
+        """Parse the raw AsciiDoc ``authors`` string into ``Author`` objects.
+
+        Recognises the AsciiDoc simple table format used by early mSCP
+        baselines::
+
+            *macOS Security Compliance Project*
+
+            |===
+            |Jordy Witteman|Root3
+            |Aron van den Herik|Root3
+            |===
+
+        Each row between the ``|===`` delimiters is split on ``|`` and the
+        first two cells become ``name`` and ``organization``.
+
+        If no table is present the entire string (stripped of AsciiDoc
+        emphasis markers) is used as a single author name with no
+        organization.
+
+        Authors whose names do not appear in ``mscp_data["authors"]`` are
+        marked ``additional=True``, matching the behaviour of tailored
+        baselines generated by `Baseline.create_new`.
+
+        Returns:
+            list[Author]: Parsed author entries, with ``additional`` set
+                appropriately for each.
+        """
+        from ..common_utils import mscp_data
+
+        # Build a case-insensitive set of known MSCP author names.
+        known_names: set[str] = {
+            a["name"].strip().lower()
+            for a in mscp_data.get("authors", [])
+            if isinstance(a.get("name"), str)
+        }
+
+        raw_authors: list[tuple[str, str | None]] = []
+        in_table: bool = False
+
+        for raw_line in self.authors.splitlines():
+            line = raw_line.strip()
+            if line == "|===":
+                in_table = not in_table
+                continue
+            if in_table and line.startswith("|"):
+                parts = line.split("|")
+                # parts: ["", "Name", "Organization"]
+                name = parts[1].strip() if len(parts) > 1 else ""
+                org = parts[2].strip() if len(parts) > 2 else ""
+                if name:
+                    raw_authors.append((name, org if org else None))
+
+        if not raw_authors:
+            # No table found — strip AsciiDoc markup and use what remains.
+            clean = re.sub(r"\*[^*]*\*", "", self.authors).strip()
+            if clean:
+                raw_authors.append((clean, None))
+
+        return [
+            Author(
+                name=name,
+                organization=org,
+                additional=True if name.strip().lower() not in known_names else None,
+            )
+            for name, org in raw_authors
+        ]
+
+    def parse_platform(self) -> dict[str, Any]:
+        """Infer the ``platform`` dict from the baseline title.
+
+        Looks for a pattern like ``macOS 26.0`` or ``iOS 17.0`` anywhere in
+        the title.
+
+        Returns:
+            dict[str, Any]: ``{"os": "<family>", "version": <float>}``
+
+        Raises:
+            ValueError: If no recognisable platform string is found.  The
+                caller should catch this and supply ``platform=`` explicitly
+                when calling `migrate`.
+        """
+        match = _PLATFORM_RE.search(self.title)
+        if not match:
+            raise ValueError(
+                f"Cannot infer platform from title {self.title!r}. "
+                "Pass platform={'os': '<family>', 'version': <float>} "
+                "explicitly to migrate()."
+            )
+        return {"os": match.group(1), "version": float(match.group(2))}
+
+    # ------------------------------------------------------------------
+    # Migration
+    # ------------------------------------------------------------------
+
+    def migrate(
+        self,
+        output_path: Path,
+        platform: dict[str, Any] | None = None,
+        language: str = "en",
+    ) -> list[str]:
+        """Convert this legacy baseline to the current format and write it.
+
+        Collects every rule ID across all legacy profile sections, looks each
+        one up in the *current* rule library for the target platform, and
+        builds a new baseline via `Baseline.create_new`.  Rules are placed
+        into the sections defined by the current library — the legacy section
+        groupings are not preserved.  The original ``title`` and
+        ``description`` are carried over unchanged.
+
+        Args:
+            output_path (Path): Destination file for the migrated baseline.
+            platform (dict[str, Any] | None): Target platform as
+                ``{"os": "<family>", "version": <float>}`` (e.g.
+                ``{"os": "macOS", "version": 26.0}``).  When ``None``,
+                the platform is inferred from `title` via `parse_platform`.
+                Pass this explicitly when the title does not contain a
+                recognisable platform string, or to override the inferred
+                value.
+            language (str): Language code forwarded to the rule loader.
+                Defaults to ``"en"``.
+
+        Returns:
+            list[str]: Rule IDs from the legacy file that were **not** found
+                in the current rule library for the target platform.  An
+                empty list means every rule resolved successfully.
+
+        Raises:
+            ValueError: If *platform* is ``None`` and cannot be inferred
+                from the title.
+        """
+        # 1. Resolve platform.
+        resolved = platform if platform is not None else self.parse_platform()
+        os_type: str = resolved["os"]
+        os_version: float = float(resolved["version"])
+
+        # 2. Collect all rule IDs, preserving first-seen order and
+        #    deduplicating across sections.
+        seen: set[str] = set()
+        legacy_rule_ids: list[str] = []
+        for prof in self.profile:
+            for rule_id in prof.rules:
+                if rule_id not in seen:
+                    legacy_rule_ids.append(rule_id)
+                    seen.add(rule_id)
+
+        logger.info(
+            "Migrating legacy baseline: {} rule IDs across {} sections",
+            len(legacy_rule_ids),
+            len(self.profile),
+        )
+
+        # 3. Load the current rule library for the target platform/version.
+        #    collect_all_rules assigns each rule its current section, so the
+        #    resulting baseline will reflect today's section structure.
+        all_current_rules = Macsecurityrule.collect_all_rules(
+            os_type=os_type,
+            os_version=int(os_version),
+            parent_values=self.parent_values or "default",
+        )
+        current_by_id: dict[str, Macsecurityrule] = {
+            r.rule_id: r for r in all_current_rules
+        }
+
+        # 4. Match each legacy rule ID against the current library.
+        found_rules: list[Macsecurityrule] = []
+        missing: list[str] = []
+        for rule_id in legacy_rule_ids:
+            rule = current_by_id.get(rule_id)
+            if rule is not None:
+                found_rules.append(rule)
+            else:
+                missing.append(rule_id)
+                logger.warning(
+                    "Rule {!r} not found in current {} {} library — skipping",
+                    rule_id,
+                    os_type,
+                    os_version,
+                )
+
+        logger.info(
+            "{} rules resolved, {} not found in current library",
+            len(found_rules),
+            len(missing),
+        )
+
+        # 5. Build the new baseline, preserving the original title and
+        #    description instead of synthesising them from the other args.
+        Baseline.create_new(
+            output_file=output_path,
+            rules=found_rules,
+            baseline_name=None,
+            authors=self.parse_authors(),
+            full_title="",
+            benchmark=self.parent_values,
+            os_type=os_type,
+            os_version=os_version,
+            baseline_dict={"title": self.title, "description": self.description},
+            language=language,
+        )
+
+        return missing
+
+    @classmethod
+    def migrate_file(
+        cls,
+        source: Path,
+        output: Path,
+        platform: dict[str, Any] | None = None,
+        language: str = "en",
+    ) -> list[str]:
+        """Convenience: load *source* and write the migrated YAML to *output*.
+
+        Equivalent to ``LegacyBaseline.from_yaml(source).migrate(output, ...)``.
+
+        Args:
+            source (Path): Path to the legacy baseline YAML.
+            output (Path): Destination path for the migrated file.
+            platform (dict[str, Any] | None): Override the platform inferred
+                from the title. See `migrate` for the expected format.
+            language (str): Language code forwarded to the rule loader.
+
+        Returns:
+            list[str]: Rule IDs not found in the current library (see
+                `migrate`).
+        """
+        return cls.from_yaml(source).migrate(output, platform=platform, language=language)

--- a/src/mscp/classes/macsecurityrule.py
+++ b/src/mscp/classes/macsecurityrule.py
@@ -22,6 +22,7 @@ from lxml import etree
 from pydantic import BaseModel, ConfigDict, Field
 
 # Local python modules
+from ._base import BaseModelWithAccessors
 from ..common_utils import (
     config,
     create_yaml,
@@ -61,47 +62,6 @@ class Sectionmap(StrEnum):
     SYSTEM_SETTINGS = "systemsettings"
     SETTINGS = "systemsettings"
     EXCLUDED = "excluded"
-
-
-class BaseModelWithAccessors(BaseModel):
-    """Pydantic base class with dict-style accessors.
-
-    Adds `get` plus ``__getitem__`` / ``__setitem__`` so subclasses can be
-    treated either as Pydantic models or as plain dict-like objects. This
-    variant differs from the one in `mscp.classes.baseline` only in that
-    `__getitem__` / `__setitem__` use `getattr` / `setattr` directly, so any
-    attribute that exists on the instance (declared field or otherwise) is
-    accessible.
-    """
-
-    def get(self, attr: str, default: Any = None) -> Any:
-        """Return the value of `attr`, or `default` if it isn't set.
-
-        Args:
-            attr (str): Attribute name to read.
-            default (Any): Value returned when ``attr`` is absent.
-                Defaults to ``None``.
-
-        Returns:
-            Any: The attribute value, or ``default`` if no such attribute
-                exists on the instance.
-        """
-        return getattr(self, attr, default)
-
-    def __getitem__(self, key: str) -> Any:
-        """Dict-style read; raises `KeyError` if the attribute is missing."""
-        try:
-            return getattr(self, key)
-        except AttributeError:
-            raise KeyError(key) from None
-
-    def __setitem__(self, key: str, value: Any) -> None:
-        """Dict-style write; raises `KeyError` if the attribute is forbidden."""
-        try:
-            setattr(self, key, value)
-        except AttributeError:
-            # This triggers if Pydantic config is set to 'forbid'
-            raise KeyError(f"{key} is not a valid attribute")
 
 
 class NistReferences(BaseModelWithAccessors):

--- a/src/mscp/cli.py
+++ b/src/mscp/cli.py
@@ -28,6 +28,8 @@ from .common_utils import (
     get_supported_languages,
     mscp_data,
     config,
+    ensure_custom_dirs,
+    set_custom_dir,
     validate_rule_folder_structure,
 )
 from .generate import (
@@ -701,7 +703,8 @@ compliance script (e.g. disa_stig, cis.benchmark)
         if args.output_dir:
             config["output_dir"] = str(args.output_dir.expanduser().resolve())
         if args.custom_dir:
-            config["custom_dir"] = str(args.custom_dir.expanduser().resolve())
+            set_custom_dir(args.custom_dir.expanduser().resolve())
+        ensure_custom_dirs()
     except argparse.ArgumentError as e:
         logger.error("Argument Error: {}", e)
         parser.print_help()

--- a/src/mscp/cli.py
+++ b/src/mscp/cli.py
@@ -320,6 +320,14 @@ def parse_cli() -> None:
         action="store_true",
     )
     baseline_parser.add_argument(
+        "-m",
+        "--migrate",
+        type=validate_file,
+        metavar="LEGACY_BASELINE",
+        help="migrate a legacy (pre-2.0) baseline YAML to the current format",
+        action="store",
+    )
+    baseline_parser.add_argument(
         "-t",
         "--tailor",
         help="create a customized baseline that is based on your organization's requirements",
@@ -742,5 +750,9 @@ compliance script (e.g. disa_stig, cis.benchmark)
         if len(sys.argv) == 2:
             baseline_parser.print_help()
             sys.exit()
+        if not args.migrate and not args.keyword and not args.list_tags:
+            logger.error("One of --keyword, --list_tags, or --migrate is required.")
+            baseline_parser.print_help()
+            sys.exit(1)
 
     args.func(args)

--- a/src/mscp/common_utils/__init__.py
+++ b/src/mscp/common_utils/__init__.py
@@ -3,7 +3,8 @@
 
 Re-exports the loguru logger (`logger`), file I/O helpers
 (create / open / remove for YAML, JSON, plist, CSV, text), the
-configuration model (`config`, `set_custom_dir`, `ensure_custom_dirs`),
+configuration model (`config`, `set_custom_dir`, `ensure_custom_dirs`,
+`search_paths`),
 input validation utilities (`sanitize_input`, `prompt_for_odv`,
 `validate_yaml_file`, `validate_rule_folder_structure`), localization
 helpers (`get_supported_languages`), version metadata accessors
@@ -12,7 +13,7 @@ runner (`run_command`), and the spinner decorator
 (`conditional_inject_spinner`).
 """
 
-from .config import config, set_custom_dir, ensure_custom_dirs
+from .config import config, set_custom_dir, ensure_custom_dirs, search_paths
 from .constants import SCHEMA_PATH, APPLE_OS, NIX_OS
 from .customization import collect_overrides
 from .file_handling import (
@@ -71,6 +72,7 @@ __all__ = [
     "config",
     "set_custom_dir",
     "ensure_custom_dirs",
+    "search_paths",
     "CONFIG_PATH",
     "SCHEMA_PATH",
     "APPLE_OS",

--- a/src/mscp/common_utils/config.py
+++ b/src/mscp/common_utils/config.py
@@ -73,7 +73,7 @@ for _key in ("output_dir", "custom_dir"):
 
 # Custom base: now guaranteed absolute.
 _custom_base: Path = Path(config["custom_dir"])
-_defaults_only = frozenset({"locales_dir", "shell_template_dir"})
+_defaults_only = frozenset({"locales_dir"})
 
 config["custom"] = {
     "root_dir": str(_custom_base),
@@ -83,6 +83,34 @@ for _key in _pkg_dir_keys - _defaults_only:
     config["custom"][_key] = str(
         _custom_base / Path(config[_key]).relative_to(_pkg_data)
     )
+
+
+def search_paths(dir_key: str) -> list[str]:
+    """Return an ordered list of directories for *dir_key*, custom first.
+
+    The custom path is only included when it exists on disk, so the list
+    is safe to pass directly to a Jinja2 ``FileSystemLoader`` or any
+    similar ordered-search loader.  The bundled path is always appended
+    as the final fallback.
+
+    Args:
+        dir_key (str): A key present in both ``config`` (bundled path) and
+            ``config["custom"]`` (custom override path), e.g.
+            ``"documents_templates_dir"``, ``"shell_template_dir"``,
+            ``"sections_dir"``.
+
+    Returns:
+        list[str]: ``[custom_path, bundled_path]`` when the custom directory
+            exists on disk, otherwise ``[bundled_path]``.
+    """
+    paths: list[str] = []
+    custom_dir = config["custom"].get(dir_key)
+    if custom_dir:
+        p = Path(custom_dir)
+        if p.exists():
+            paths.append(str(p))
+    paths.append(config[dir_key])
+    return paths
 
 
 def ensure_custom_dirs() -> None:

--- a/src/mscp/data/templates/documents/adoc/additional_docs.adoc.jinja
+++ b/src/mscp/data/templates/documents/adoc/additional_docs.adoc.jinja
@@ -84,6 +84,7 @@
 |===
 |{% trans %}Document Number or Descriptor{% endtrans %}
 |{% trans %}Document Title{% endtrans %}
+
 {% if os_name == "macos" %}
 {% if os_version == "15.0" %}
 |link:https://www.cisecurity.org/benchmark/apple_os/[Apple macOS 15.0]|_CIS Apple macOS 15.0 Benchmark version 1.0.0_
@@ -103,5 +104,6 @@
 |link:https://www.cisecurity.org/benchmark/apple_ios[Apple iOS/iPadOS]|_CIS Apple iOS 16 and iPadOS 16 Version 1.1.0_
 {% endif %}
 
-|===
 {% endif %}
+
+|===

--- a/src/mscp/data/templates/documents/adoc/additional_docs.adoc.jinja
+++ b/src/mscp/data/templates/documents/adoc/additional_docs.adoc.jinja
@@ -48,6 +48,7 @@
 |===
 {% endif %}
 
+{% if "CMMC" in baseline.title.upper() %}
 [%header, cols=2*a]
 .Cybersecurity Maturity Model Certification (CMMC)
 |===
@@ -55,7 +56,9 @@
 |{% trans %}Document Title{% endtrans %}
 |link:https://dodcio.defense.gov/Portals/0/Documents/CMMC/ModelOverview_V2.0_FINAL2_20211202_508.pdf[CMMC Model Overview v2.0]|_Cybersecurity Maturity Model Certification (CMMC) Model Overview v2.0_
 |===
+{% endif %}
 
+{% if "CNSSI" in baseline.title.upper() %}
 [%header, cols=2*a]
 .Committee on National Security Systems (CNSS)
 |===
@@ -63,6 +66,7 @@
 |{% trans %}Document Title{% endtrans %}
 |link:https://www.cnss.gov/CNSS/issuances/Instructions.cfm[CNSSI No. 1253]|_Security Categorization and Control Selection for National Security Systems_
 |===
+{% endif %}
 
 === {% trans %}Non-Government Documents{% endtrans %}
 
@@ -79,6 +83,7 @@
 |===
 {% endif %}
 
+{% if "CIS_LVL" in baseline.title.upper() %}
 [%header, cols=2*a]
 .Center for Internet Security
 |===
@@ -107,3 +112,4 @@
 {% endif %}
 
 |===
+{% endif %}

--- a/src/mscp/data/templates/documents/markdown/additional_docs.md.jinja
+++ b/src/mscp/data/templates/documents/markdown/additional_docs.md.jinja
@@ -11,7 +11,7 @@
 | [NIST Special Publication 800-171](https://csrc.nist.gov/pubs/sp/800/171/r3/final)                  | _NIST Special Publication 800-171 Rev 3_    |
 | [NIST Special Publication 800-219](https://csrc.nist.gov/pubs/sp/800/219/r1/final)                  | _NIST Special Publication 800-219 Rev 1_    |
 
-{% if "STIG" in baseline.title %}
+{% if "STIG" in baseline.title.upper() %}
 #### Defense Information Systems Agency (DISA)
 
 | Document Number or Descriptor | Document Title |
@@ -41,17 +41,21 @@
 {% endif %}
 {% endif %}
 
+{% if "CMMC" in baseline.title.upper() %}
 #### Cybersecurity Maturity Model Certification (CMMC)
 
 | Document Number or Descriptor | Document Title |
 |----------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------|
 | [CMMC Model Overview v2.0](https://dodcio.defense.gov/Portals/0/Documents/CMMC/ModelOverview_V2.0_FINAL2_20211202_508.pdf) | _Cybersecurity Maturity Model Certification (CMMC) Model Overview v2.0_ |
+{% endif %}
 
+{% if "CNSSI" in baseline.title.upper() %}
 #### Committee on National Security Systems (CNSS)
 
 | Document Number or Descriptor | Document Title |
 |------------------------------------------------------------------------|-------------------------------------------------------------------------------|
 | [CNSSI No. 1253](https://www.cnss.gov/CNSS/issuances/Instructions.cfm) | _Security Categorization and Control Selection for National Security Systems_ |
+{% endif %}
 
 ### Non-Government Documents
 
@@ -64,6 +68,7 @@
 | [Apple Platform Certifications](https://support.apple.com/guide/certifications/welcome/web)                               | _Apple Platform Certifications_ |
 | [Profile-Specific Payload Keys](https://developer.apple.com/documentation/devicemanagement/profile-specific_payload_keys) | _Profile-Specific Payload Keys_ |
 
+{% if "CIS_LVL" in baseline.title.upper() %}
 #### Center for Internet Security
 
 | Document Number or Descriptor | Document Title |
@@ -88,4 +93,6 @@
 {% endif %}
 {% elif os_name == "visionos" %}
 | Apple visionOS                                                     | _Currently Unavailable_                        |
+{% endif %}
+
 {% endif %}

--- a/src/mscp/data/templates/documents/markdown/rule.md.jinja
+++ b/src/mscp/data/templates/documents/markdown/rule.md.jinja
@@ -147,10 +147,10 @@
           <td>{{ rule.references.nist.cce | render_rules }}</td>
         </tr>
         {% endif %}
-        {% if custom %}
+        {% if custom and rule.references.custom_refs is not none %}
         <tr>
           <td><strong>Custom References</strong></td>
-          <td>{{ rule.references.custom_refs | render_rules if rule.references.cce is not none }}</td>
+          <td>{{ rule.references.custom_refs | render_rules }}</td>
         </tr>
         {% endif %}
         {% if show_all_tags %}

--- a/src/mscp/generate/baseline.py
+++ b/src/mscp/generate/baseline.py
@@ -16,6 +16,7 @@ from typing import Any
 
 # Local python modules
 from ..classes import Author, Baseline, Macsecurityrule
+from ..classes.legacy_baseline import LegacyBaseline
 from ..common_utils import (
     config,
     logger,
@@ -154,6 +155,88 @@ def rule_has_benchmark_for_version(
     return False
 
 
+def migrate_legacy_baseline(args: argparse.Namespace) -> None:
+    """Migrate a legacy (pre-2.0) baseline YAML to the current format.
+
+    Reads the file supplied via ``args.migrate``, resolves each rule ID
+    against the current rule library, and writes the migrated baseline to
+    the custom baselines directory.  Any rule IDs that are not found in the
+    current library are reported but do not abort the migration.
+
+    Platform is inferred from the legacy file's title.  When inference
+    fails, the ``--os_name`` / ``--os_version`` flags supplied on the
+    command line are used as the fallback.
+
+    Args:
+        args (argparse.Namespace): Parsed CLI arguments.  ``args.migrate``
+            must be a ``Path`` to the legacy YAML; ``args.os_name`` and
+            ``args.os_version`` are used as a platform fallback.
+    """
+    source: Path = args.migrate
+    build_path: Path = Path(config["custom"].get("baseline_dir", ""))
+
+    if not build_path.exists():
+        make_dir(build_path)
+
+    if not LegacyBaseline.is_legacy(source):
+        logger.error(
+            "{} does not appear to be a legacy baseline — "
+            "authors is already a list and platform is present. "
+            "No migration needed.",
+            source,
+        )
+        sys.exit(1)
+
+    lb = LegacyBaseline.from_yaml(source)
+
+    # Attempt to infer platform from the title; fall back to the CLI flags.
+    platform_override: dict | None = None
+    try:
+        inferred = lb.parse_platform()
+        os_name_lower: str = inferred["os"].lower()
+        os_version: float = inferred["version"]
+        logger.info(
+            "Platform inferred from title: {} {}",
+            inferred["os"],
+            os_version,
+        )
+    except ValueError:
+        logger.warning(
+            "Cannot infer platform from title {!r}. "
+            "Using --os_name={} --os_version={} from command line.",
+            lb.title,
+            args.os_name,
+            args.os_version,
+        )
+        platform_override = {"os": args.os_name, "version": args.os_version}
+        os_name_lower = args.os_name
+        os_version = args.os_version
+
+    # Name matches the format used by generate_baseline:
+    # {parent_values}_{os_name}_{os_version}.yaml
+    output_filename: str = f"{lb.parent_values}_{os_name_lower}_{os_version}.yaml"
+    output_path: Path = build_path / output_filename
+
+    missing = lb.migrate(output_path, platform=platform_override)
+
+    try:
+        display_path = output_path.relative_to(Path.cwd())
+    except ValueError:
+        display_path = output_path
+
+    print(f"\nMigrated baseline written to: {display_path}")
+
+    if missing:
+        print(
+            f"\n{len(missing)} rule(s) from the legacy file were not found "
+            "in the current library and were skipped:"
+        )
+        for rule_id in missing:
+            print(f"  - {rule_id}")
+    else:
+        print("All rules resolved successfully.")
+
+
 @logger.catch
 def generate_baseline(args: argparse.Namespace, admin=False) -> None:
     """Generate a YAML baseline file for the specified OS and keyword.
@@ -170,6 +253,10 @@ def generate_baseline(args: argparse.Namespace, admin=False) -> None:
             default baseline directory instead of the custom directory.
             Defaults to ``False``.
     """
+    if getattr(args, "migrate", None):
+        migrate_legacy_baseline(args)
+        return
+
     if admin:
         build_path: Path = Path(config.get("baseline_dir", "")) / args.os_name
     else:

--- a/src/mscp/generate/guidance.py
+++ b/src/mscp/generate/guidance.py
@@ -183,7 +183,7 @@ def generate_guidance(sp: Yaspin, args: argparse.Namespace) -> None:
         html_css: str = "asciidoctor.css"
 
     _custom_root = Path(config["custom"]["root_dir"])
-    custom: bool = not (_custom_root.exists() and any(_custom_root.iterdir()))
+    custom: bool = _custom_root.exists() and any(_custom_root.iterdir())
     show_all_tags: bool = False
 
     output_basename: str = args.baseline.name
@@ -201,7 +201,7 @@ def generate_guidance(sp: Yaspin, args: argparse.Namespace) -> None:
         build_path, f"{baseline_name}_{args.language}.xlsx"
     )
 
-    baseline: Baseline = Baseline.from_yaml(args.baseline, args.language, custom)
+    baseline: Baseline = Baseline.from_yaml(args.baseline, args.language)
 
     current_version_data: dict[str, Any] = get_version_data(
         baseline.platform["os"], baseline.platform["version"], mscp_data
@@ -213,9 +213,11 @@ def generate_guidance(sp: Yaspin, args: argparse.Namespace) -> None:
     if args.logo:
         logo_path = args.logo
     else:
-        logo_path = Path(
-            config["images_dir"],
-            f"mscp_banner_{baseline.platform['os'].lower()}_{'dark' if args.dark else 'light'}.png",
+        _logo_filename = f"mscp_banner_{baseline.platform['os'].lower()}_{'dark' if args.dark else 'light'}.png"
+        _custom_logo = Path(config["custom"]["images_dir"], _logo_filename)
+        logo_path = (
+            _custom_logo if _custom_logo.exists()
+            else Path(config["images_dir"], _logo_filename)
         ).absolute()
 
     if not logo_path.exists():
@@ -323,7 +325,6 @@ def generate_guidance(sp: Yaspin, args: argparse.Namespace) -> None:
             baseline.platform["os"],
             current_version_data,
             show_all_tags,
-            custom,
             output_format="markdown",
             language=args.language,
         )
@@ -393,7 +394,6 @@ def generate_guidance(sp: Yaspin, args: argparse.Namespace) -> None:
             baseline.platform["os"],
             current_version_data,
             show_all_tags,
-            custom,
             output_format="markdown",
             language=args.language,
         )
@@ -415,7 +415,6 @@ def generate_guidance(sp: Yaspin, args: argparse.Namespace) -> None:
         baseline.platform["os"],
         current_version_data,
         show_all_tags,
-        custom,
         language=args.language,
     )
     try:

--- a/src/mscp/generate/guidance.py
+++ b/src/mscp/generate/guidance.py
@@ -24,6 +24,7 @@ from yaspin.spinners import Spinners
 
 # Local python modules
 from ..classes import Baseline
+from ..classes.legacy_baseline import LegacyBaseline
 from ..common_utils import (
     config,
     get_version_data,
@@ -76,6 +77,70 @@ def verify_signing_hash(cert_hash: str) -> bool:
     return True
 
 
+def _auto_migrate_legacy(args: argparse.Namespace) -> Path:
+    """Migrate a legacy baseline to the current format and return the new path.
+
+    Called transparently by `generate_guidance` when the provided baseline
+    file is detected as pre-2.0 format.  The migrated YAML is written to the
+    custom baselines directory using the standard naming convention
+    ``{parent_values}_{os_name}_{os_version}.yaml``.
+
+    Platform is inferred from the baseline title.  If inference fails, the
+    ``--os_name`` / ``--os_version`` flags on ``args`` are used as a fallback.
+
+    Args:
+        args (argparse.Namespace): Parsed CLI arguments. ``args.baseline``
+            must be the path to the legacy YAML file; ``args.os_name`` and
+            ``args.os_version`` serve as a platform fallback.
+
+    Returns:
+        Path: Path to the migrated baseline YAML.
+    """
+    source: Path = args.baseline
+    baseline_dir: Path = Path(config["custom"].get("baseline_dir", ""))
+
+    if not baseline_dir.exists():
+        make_dir(baseline_dir)
+
+    lb = LegacyBaseline.from_yaml(source)
+
+    platform_override: dict | None = None
+    try:
+        inferred = lb.parse_platform()
+        os_name_lower: str = inferred["os"].lower()
+        os_version: float = inferred["version"]
+    except ValueError:
+        logger.warning(
+            "Cannot infer platform from legacy baseline title {!r}. "
+            "Using --os_name={} --os_version={} from command line.",
+            lb.title,
+            args.os_name,
+            args.os_version,
+        )
+        platform_override = {"os": args.os_name, "version": args.os_version}
+        os_name_lower = args.os_name
+        os_version = args.os_version
+
+    output_path: Path = (
+        baseline_dir / f"{lb.parent_values}_{os_name_lower}_{os_version}.yaml"
+    )
+
+    missing = lb.migrate(output_path, platform=platform_override)
+
+    logger.info(
+        "Auto-migrated legacy baseline {} → {}", source.name, output_path.name
+    )
+    if missing:
+        logger.warning(
+            "{} rule(s) from the legacy baseline were not found in the "
+            "current library and were skipped: {}",
+            len(missing),
+            ", ".join(missing),
+        )
+
+    return output_path
+
+
 @conditional_inject_spinner()
 def generate_guidance(sp: Yaspin, args: argparse.Namespace) -> None:
     """Orchestrate all guidance artifacts for a given baseline.
@@ -93,6 +158,17 @@ def generate_guidance(sp: Yaspin, args: argparse.Namespace) -> None:
             ``script``, ``xlsx``, ``gary``, ``markdown``, ``manifest``,
             ``all``, ``consolidated_profile``, ``granular_profiles``.
     """
+    # Transparently migrate legacy (pre-2.0) baselines before deriving any
+    # paths. Updating args.baseline here means all subsequent path derivations
+    # (basename, build_path, adoc_output_file, …) use the migrated file
+    # automatically.
+    if LegacyBaseline.is_legacy(args.baseline):
+        logger.info(
+            "Legacy baseline detected: {}. Migrating before generating guidance.",
+            args.baseline.name,
+        )
+        args.baseline = _auto_migrate_legacy(args)
+
     # Configure localization at the beginning based on the CLI language parameter
     logger.debug(f"Language parameter from CLI: {args.language}")
 

--- a/src/mscp/generate/guidance_support/documents.py
+++ b/src/mscp/generate/guidance_support/documents.py
@@ -33,6 +33,7 @@ from ...common_utils import (
     mscp_data,
     open_file,
     run_command,
+    search_paths,
     NIX_OS,
 )
 
@@ -145,27 +146,35 @@ def render_references(reference_set: Sequence[Dict[str, Any]]) -> str:
     return "\n".join("!" + "\n!\n- ".join(r) for r in padded)
 
 
-def render_rules(rule_set: list[str]) -> str:
+def render_rules(rule_set: list[str] | None) -> str:
     """Render a list of rule strings as newline-separated ``"- <rule>"`` lines.
 
     Args:
-        rule_set (list[str]): Rule strings to render.
+        rule_set (list[str] | None): Rule strings to render. ``None`` or an
+            empty value returns an empty string.
 
     Returns:
-        str: Newline-joined bullet lines.
+        str: Newline-joined bullet lines, or ``""`` when *rule_set* is empty
+            or ``None``.
     """
+    if not rule_set:
+        return ""
     return "\n".join(f"- {rule}" for rule in rule_set)
 
 
-def render_rules_md(rule_set: list[str]) -> str:
+def render_rules_md(rule_set: list[str] | None) -> str:
     """Render a list of rule strings as ``<br>``-joined ``"- <rule>"`` lines for Markdown.
 
     Args:
-        rule_set (list[str]): Rule strings to render.
+        rule_set (list[str] | None): Rule strings to render. ``None`` or an
+            empty value returns an empty string.
 
     Returns:
-        str: ``<br>``-joined bullet lines.
+        str: ``<br>``-joined bullet lines, or ``""`` when *rule_set* is empty
+            or ``None``.
     """
+    if not rule_set:
+        return ""
     return "<br>".join(f"- {rule}" for rule in rule_set)
 
 
@@ -359,6 +368,29 @@ def get_nested(
     return current
 
 
+def _resolve_asset_dir(filename: str, dir_key: str) -> str:
+    """Return the directory that contains *filename*, preferring custom.
+
+    Checks whether ``config["custom"][dir_key] / filename`` exists.  If so,
+    returns the custom directory path; otherwise returns the bundled path
+    from ``config[dir_key]``.  This allows a user to drop a single custom
+    theme or image file into their custom directory and have it shadow the
+    bundled default without replacing the entire directory.
+
+    Args:
+        filename (str): The asset filename to look up (e.g. ``"mscp_theme.yml"``).
+        dir_key (str): Config key shared between ``config`` and
+            ``config["custom"]`` (e.g. ``"themes_dir"``).
+
+    Returns:
+        str: Absolute path to the directory that should be used.
+    """
+    custom_dir = Path(config["custom"].get(dir_key, ""))
+    if custom_dir.exists() and (custom_dir / filename).exists():
+        return str(custom_dir)
+    return config[dir_key]
+
+
 def render_template(
     output_file: Path,
     template_name: str,
@@ -371,7 +403,7 @@ def render_template(
     version_info: dict[str, Any],
     show_all_tags: bool,
     custom: bool,
-    template_dir: str,
+    template_dirs: list[str],
     themes_dir: str,
     logo_dir: str,
     output_format: str = "adoc",
@@ -385,7 +417,7 @@ def render_template(
 
     Args:
         output_file (Path): Destination for the rendered output.
-        template_name (str): Filename of the template within *template_dir*.
+        template_name (str): Filename of the template within *template_dirs*.
         baseline (Baseline): Baseline data model.
         b64logo (bytes): Base64-encoded logo image bytes.
         pdf_theme (str): AsciiDoctor-PDF theme filename.
@@ -395,7 +427,9 @@ def render_template(
         version_info (dict[str, Any]): OS/compliance version metadata.
         show_all_tags (bool): Whether to render all tags in the document.
         custom (bool): Whether the baseline uses a custom configuration.
-        template_dir (str): Path to the Jinja templates directory.
+            Passed through to the Jinja template context.
+        template_dirs (list[str]): Ordered list of directories for the Jinja
+            ``FileSystemLoader``; earlier entries shadow later ones.
         themes_dir (str): Path to the themes/styles directory.
         logo_dir (str): Path to the images directory.
         output_format (str): ``"adoc"`` (default) or ``"markdown"``.
@@ -409,7 +443,7 @@ def render_template(
     )
 
     env: Environment = Environment(
-        loader=FileSystemLoader(template_dir),
+        loader=FileSystemLoader(template_dirs),
         trim_blocks=True,
         lstrip_blocks=True,
         autoescape=False,
@@ -504,40 +538,41 @@ def generate_documents(
     os_name: str,
     version_info: dict[str, Any],
     show_all_tags: bool = False,
-    custom: bool = False,
     output_format: str = "adoc",
     language: str = "en",
 ) -> None:
     """Render guidance documents and, for AsciiDoc output, invoke AsciiDoctor.
 
-    Selects standard or custom template/theme directories, calls
-    `render_template`, then (when *output_format* is ``"adoc"``) runs
-    ``bundle exec asciidoctor`` and ``bundle exec asciidoctor-pdf`` to
-    produce HTML and PDF output.
+    Resolves template, theme, and image directories by searching the custom
+    directory first and falling back to the bundled defaults, then calls
+    `render_template`.  For AsciiDoc output also runs ``bundle exec
+    asciidoctor`` and ``bundle exec asciidoctor-pdf`` to produce HTML and
+    PDF output.
 
     Args:
         spinner (Yaspin): Spinner for progress feedback.
         output_file (Path): Destination ``.adoc`` or ``.md`` file.
         baseline (Baseline): Baseline data model.
         b64logo (bytes): Base64-encoded logo image bytes.
-        pdf_theme (str): AsciiDoctor-PDF theme filename.
+        pdf_theme (str): AsciiDoctor-PDF theme filename or absolute path.
         html_css (str): CSS filename for HTML output.
         logo_path (Path): Absolute path to the logo file.
         os_name (str): Operating system name string.
         version_info (dict[str, Any]): OS/compliance version metadata.
         show_all_tags (bool): Whether to render all tags. Defaults to ``False``.
-        custom (bool): Whether to use the custom template directory. Defaults to ``False``.
         output_format (str): ``"adoc"`` (default) or ``"markdown"``.
         language (str): BCP-47 language code. Defaults to ``"en"``.
     """
-    template_dir: str = config["documents_templates_dir"]
-    themes_dir: str = config["themes_dir"]
-    logo_dir: str = config["images_dir"]
+    # Determine whether any custom content is active (for template context).
+    _custom_root = Path(config["custom"]["root_dir"])
+    custom: bool = _custom_root.exists() and any(_custom_root.iterdir())
 
-    if custom:
-        template_dir = config["custom"]["documents_templates_dir"]
-        themes_dir = config["custom"]["themes_dir"]
-        logo_dir = config["custom"]["images_dir"]
+    # Templates: custom files shadow bundled ones via ordered search paths.
+    _template_dirs: list[str] = search_paths("documents_templates_dir")
+
+    # Static assets: prefer the custom directory when it contains the file.
+    _themes_dir: str = _resolve_asset_dir(pdf_theme, "themes_dir")
+    _logo_dir: str = _resolve_asset_dir(logo_path.name, "images_dir")
 
     render_template(
         output_file,
@@ -551,9 +586,9 @@ def generate_documents(
         version_info,
         show_all_tags,
         custom,
-        template_dir,
-        themes_dir,
-        logo_dir,
+        _template_dirs,
+        _themes_dir,
+        _logo_dir,
         output_format,
         language,
     )

--- a/src/mscp/generate/guidance_support/documents.py
+++ b/src/mscp/generate/guidance_support/documents.py
@@ -441,7 +441,12 @@ def render_template(
     baseline_dict: dict[str, Any] = baseline.model_dump()
     acronyms_data: dict[str, Any] = open_file(acronyms_file, language)
 
-    html_title, html_subtitle = map(str.strip, baseline.title.split(":", 1))
+    _title_parts = baseline.title.split(":", 1)
+    if len(_title_parts) == 2:
+        html_title, html_subtitle = map(str.strip, _title_parts)
+    else:
+        html_title = baseline.title.strip()
+        html_subtitle = ""
     document_subtitle2: str = ":document-subtitle2:"
 
     if "Tailored from" in baseline.title:

--- a/src/mscp/generate/guidance_support/documents.py
+++ b/src/mscp/generate/guidance_support/documents.py
@@ -459,7 +459,7 @@ def render_template(
         baseline_dict["tailored"] = False
         baseline_dict["benchmark_description"] = benchmark_description
 
-    if any(author.is_additional() for author in baseline.authors):
+    if any(author.is_additional for author in baseline.authors):
         baseline_dict["additional_authors"] = True
 
     rendered_output = template.render(

--- a/src/mscp/generate/guidance_support/script.py
+++ b/src/mscp/generate/guidance_support/script.py
@@ -17,7 +17,7 @@ from jinja2 import Environment, FileSystemLoader
 
 # Local python modules
 from ...classes import Baseline, Macsecurityrule
-from ...common_utils import config, create_file, logger, make_dir, mscp_data, NIX_OS
+from ...common_utils import config, create_file, logger, make_dir, mscp_data, search_paths, NIX_OS
 
 
 def group_ulify(elements: list[str]) -> str:
@@ -158,7 +158,7 @@ def generate_script(
 
     output_file: Path = Path(build_path, f"{baseline_name}_compliance.sh")
     env: Environment = Environment(
-        loader=FileSystemLoader(config["shell_template_dir"]),
+        loader=FileSystemLoader(search_paths("shell_template_dir")),
         trim_blocks=True,
         lstrip_blocks=True,
     )
@@ -213,7 +213,7 @@ def generate_restore_script(
 
     output_file: Path = Path(build_path, f"{baseline_name}_restore.sh")
     env: Environment = Environment(
-        loader=FileSystemLoader(config["shell_template_dir"]),
+        loader=FileSystemLoader(search_paths("shell_template_dir")),
         trim_blocks=True,
         lstrip_blocks=True,
     )

--- a/src/mscp/generate/guidance_support/script.py
+++ b/src/mscp/generate/guidance_support/script.py
@@ -12,8 +12,6 @@ Jinja filter helpers `group_ulify`, `generate_log_reference`, and
 from datetime import date
 from itertools import groupby
 from pathlib import Path
-from typing import Any
-
 # Additional python modules
 from jinja2 import Environment, FileSystemLoader
 
@@ -61,14 +59,14 @@ def generate_log_reference(rule: Macsecurityrule, reference: str) -> list[str] |
     """
     log_reference_id: list[str] | str
     try:
-        log_references = rule["references"].get_ref(reference)
+        log_references = rule.references.get_ref(reference)
     except KeyError:
         logger.warning(
-            f'Unable to find the reference "{reference}" in rule "{rule["rule_id"]}"'
+            f'Unable to find the reference "{reference}" in rule "{rule.rule_id}"'
         )
         log_references = []
     if reference == "default" or not log_references:
-        log_reference_id = rule["rule_id"]
+        log_reference_id = rule.rule_id
     else:
         log_reference_id = f"{', '.join(map(str, log_references))}"
     return log_reference_id
@@ -170,10 +168,8 @@ def generate_script(
     env.filters["log_reference"] = generate_log_reference
     env.filters["quotify"] = quotify
 
-    baseline_dict: dict[str, Any] = dict(baseline)
-
     rendered_output = script_template.render(
-        baseline=baseline_dict,
+        baseline=baseline,
         baseline_name=baseline_name,
         audit_name=audit_name,
         reference_log_id=log_reference,
@@ -227,16 +223,14 @@ def generate_restore_script(
     env.filters["log_reference"] = generate_log_reference
     env.filters["quotify"] = quotify
 
-    baseline_dict: dict[str, Any] = dict(baseline)
-
     any_rendered = any(
-        rule.get("default_state")
-        for p in baseline_dict["profile"]
-        for rule in p["rules"]
+        rule.default_state
+        for p in baseline.profile
+        for rule in p.rules
     )
 
     rendered_output = script_template.render(
-        baseline=baseline_dict,
+        baseline=baseline,
         baseline_name=baseline_name,
         audit_name=audit_name,
         reference_log_id=log_reference,


### PR DESCRIPTION
A bit of code maintenance along with some new functionality.

New legacy baseline migration tool. Now you can provide a v1.0 baseline yaml file and it will convert it to a 2.0 baseline to generate the guidance from. 

Updated the processing of the custom directory so that it better handles custom overrides of things like templates, sections, images, etc.