### PR TITLE
Align BIO references with BIO2 v1.3 iOS/iPadOS sheet

### DIFF
--- a/rules/os/os_authentication_password_autofill_enable.yaml
+++ b/rules/os/os_authentication_password_autofill_enable.yaml
@@ -25,8 +25,7 @@ references:
     controls v8:
     - 3.3
   bio:
-  - 8.27
-      - 3.3
+    - 8.27
   cmmc:
     - AC.L1-B.1.I
     - AC.L2-3.1.1

--- a/rules/os/os_external_intelligence_integration_sign_in_disable.yaml
+++ b/rules/os/os_external_intelligence_integration_sign_in_disable.yaml
@@ -32,7 +32,6 @@ references:
     - ANNEX K
   bio:
     - 8.12
-    - 8.12.01
   cmmc:
     - AC.L1-B.1.III
     - AC.L2-3.1.20

--- a/rules/os/os_force_date_and_time_enable.yaml
+++ b/rules/os/os_force_date_and_time_enable.yaml
@@ -26,8 +26,7 @@ references:
     controls v8:
     - 8.4
   bio:
-  - 8.17
-      - 8.4
+    - 8.17
   cmmc:
     - AU.L2-3.3.7
 iOS:

--- a/rules/os/os_marketplace_prevent.yaml
+++ b/rules/os/os_marketplace_prevent.yaml
@@ -19,6 +19,8 @@ references:
   indigo:
     - ANNEX K
   bio:
+    - 8.07
+    - 8.19
     - 8.27
   cmmc:
     - CM.L2-3.4.9

--- a/rules/os/os_personalized_advertising_disable.yaml
+++ b/rules/os/os_personalized_advertising_disable.yaml
@@ -29,8 +29,7 @@ references:
     controls v8:
     - 4.8
   bio:
-  - 8.12
-      - 4.8
+    - 8.12
   cmmc:
     - AC.L1-B.1.III
     - AC.L2-3.1.20

--- a/rules/os/os_supervised_mdm_require.yaml
+++ b/rules/os/os_supervised_mdm_require.yaml
@@ -25,6 +25,7 @@ references:
     controls v8:
       - N/A
   bio:
+    - 8.01
     - 8.09
     - 8.18
   cmmc:

--- a/rules/os/os_web_distribution_app_installation_disable.yaml
+++ b/rules/os/os_web_distribution_app_installation_disable.yaml
@@ -19,6 +19,8 @@ references:
   disa_stig:
     - AIOS-26-015000
   bio:
+    - 8.07
+    - 8.19
     - 8.27
   cmmc:
     - CM.L2-3.4.9

--- a/rules/pwpolicy/pwpolicy_force_pin_enable.yaml
+++ b/rules/pwpolicy/pwpolicy_force_pin_enable.yaml
@@ -26,6 +26,8 @@ references:
     controls v8:
       - N/A
   bio:
+    - 5.17
+    - 8.01
     - 8.24
   cmmc:
     - MP.L2-3.8.6


### PR DESCRIPTION
Reconcile bio references against the iOS/iPadOS 26 maatregelenset:
- Fix three malformed bio blocks that held stray CIS control numbers with bad indentation: os_authentication_password_autofill_enable (8.27), os_force_date_and_time_enable (8.17), os_personalized_advertising_ disable (8.12).
- Drop the duplicate 8.12.01 in os_external_intelligence_integration_ sign_in_disable (keeps 8.12).
- Merge in the controls the iOS sheet lists alongside existing refs: os_marketplace_prevent and os_web_distribution_app_installation_disable -> [8.07, 8.19, 8.27]; os_supervised_mdm_require -> [8.01, 8.09, 8.18]; pwpolicy_force_pin_enable -> [5.17, 8.01, 8.24].