### PR TITLE
fix(os_root_disable): set Password disabled marker when disabling root account

### DIFF
--- a/rules/os/os_root_disable.yaml
+++ b/rules/os/os_root_disable.yaml
@@ -11,8 +11,8 @@ result:
 fix: |
   [source,bash]
   ----
-  /usr/bin/fdesetup remove -user root
   /usr/bin/dscl '/Local/Default' delete '/Users/root' AuthenticationAuthority
+  /usr/bin/dscl '/Local/Default' -create '/Users/root' Password "*"
   ----
 references:
   cce:


### PR DESCRIPTION
Fixes #592

Adds `dscl -create /Users/root Password "*"` to the fix block to explicitly set the account disabled marker in Directory Services, matching Apple's documented behavior via `dsenableroot` and ensuring root is fully disabled in DS.