### PR TITLE
Report rules that can't be evaluated as "not applicable" instead of false results

### DIFF
--- a/src/mscp/data/templates/shell_scripts/check.jinja
+++ b/src/mscp/data/templates/shell_scripts/check.jinja
@@ -26,10 +26,12 @@
     # (e.g. at the login window) it cannot be evaluated, so mark it Not
     # Applicable instead of letting the command error out and count as a pass.
     if [[ -z "$CURRENT_USER" || "$CURRENT_USER" == "root" ]]; then
-      logmessage "$rule_id not_applicable - Requires a logged-in user (no console user present)"
-      logcsv "$rule_id" "N/A" "" "" ""
+      na_reason="Requires a logged-in user (no console user present)"
+      logmessage "$rule_id not_applicable - $na_reason"
+      logcsv "$rule_id" "N/A" "" "" "$na_reason"
       /usr/bin/defaults write "$audit_plist" "$rule_id" -dict-add finding -bool NO
       /usr/bin/defaults write "$audit_plist" "$rule_id" -dict-add not_applicable -bool YES
+      /usr/bin/defaults write "$audit_plist" "$rule_id" -dict-add not_applicable_reason -string "$na_reason"
     else
 {% endif %}
     local result_value=$({{ rule.check }}
@@ -63,9 +65,12 @@
 {% endif %}
 
   else
-    logmessage "$rule_id does not apply to this architecture"
-    logcsv "$rule_id" "N/A" "" "" ""
+    na_reason="Does not apply to this architecture"
+    logmessage "$rule_id not_applicable - $na_reason"
+    logcsv "$rule_id" "N/A" "" "" "$na_reason"
     /usr/bin/defaults write "$audit_plist" "$rule_id" -dict-add finding -bool NO
+    /usr/bin/defaults write "$audit_plist" "$rule_id" -dict-add not_applicable -bool YES
+    /usr/bin/defaults write "$audit_plist" "$rule_id" -dict-add not_applicable_reason -string "$na_reason"
   fi
 
   

--- a/src/mscp/data/templates/shell_scripts/check.jinja
+++ b/src/mscp/data/templates/shell_scripts/check.jinja
@@ -21,6 +21,17 @@
   exemption_output=""
 
   if [[ "$arch" == "$rule_arch" ]] || [[ -z "$rule_arch" ]]; then
+{% if "CURRENT_USER" in (rule.check | string) or "CURR_USER_UID" in (rule.check | string) %}
+    # This rule's check requires the console user. When no one is logged in
+    # (e.g. at the login window) it cannot be evaluated, so mark it Not
+    # Applicable instead of letting the command error out and count as a pass.
+    if [[ -z "$CURRENT_USER" || "$CURRENT_USER" == "root" ]]; then
+      logmessage "$rule_id not_applicable - Requires a logged-in user (no console user present)"
+      logcsv "$rule_id" "N/A" "" "" ""
+      /usr/bin/defaults write "$audit_plist" "$rule_id" -dict-add finding -bool NO
+      /usr/bin/defaults write "$audit_plist" "$rule_id" -dict-add not_applicable -bool YES
+    else
+{% endif %}
     local result_value=$({{ rule.check }}
     )
     local exempt=$(/usr/bin/osascript -l JavaScript -e "ObjC.unwrap($.NSUserDefaults.alloc.initWithSuiteName('org.$baseline_name.audit').objectForKey('$rule_id'))['exempt']")
@@ -40,12 +51,16 @@
     logmessage "$log_reference_id $result_status (Result: $result_value, Expected: \"$expected_result\") $exemption_output"
     logcsv "$rule_id" "$result_status" "$result_value" "$expected_result" "$exemption_output"
     /usr/bin/defaults write "$audit_plist" "$rule_id" -dict-add finding -bool $finding
+    /usr/bin/defaults write "$audit_plist" "$rule_id" -dict-add not_applicable -bool NO
 
     if [[ ! "$customref" == "$rule_id" ]]; then
       /usr/bin/defaults write "$audit_plist" "$rule_id" -dict-add reference -string "$customref"
     fi
 
     /usr/bin/logger "mSCP: $baseline_name - $log_reference_id $result_status (Result: $result_value, Expected: \"$expected_result\") $exemption_output"
+{% if "CURRENT_USER" in (rule.check | string) or "CURR_USER_UID" in (rule.check | string) %}
+    fi
+{% endif %}
 
   else
     logmessage "$rule_id does not apply to this architecture"

--- a/src/mscp/data/templates/shell_scripts/compliance_script.sh.jinja
+++ b/src/mscp/data/templates/shell_scripts/compliance_script.sh.jinja
@@ -71,7 +71,12 @@ plb="/usr/libexec/PlistBuddy"
 
 # get the currently logged in user and hostname
 CURRENT_USER=$( /usr/sbin/scutil <<< "show State:/Users/ConsoleUser" | /usr/bin/awk '/Name :/ && ! /loginwindow/ { print $3 }')
-CURR_USER_UID=$(/usr/bin/id -u $CURRENT_USER)
+# guard against an empty/root console user (e.g. at the login window) so id -u does not error
+if [[ -z "$CURRENT_USER" || "$CURRENT_USER" == "root" ]]; then
+  CURR_USER_UID=""
+else
+  CURR_USER_UID=$(/usr/bin/id -u "$CURRENT_USER")
+fi
 CURR_HOSTNAME=$(/usr/sbin/scutil --get HostName)
 
 # get system architecture
@@ -224,6 +229,11 @@ compliance_count(){
   rule_names=($(/usr/libexec/PlistBuddy -c "Print" $audit_plist | awk '/= Dict/ {print $1}'))
 
   for rule in ${rule_names[@]}; do
+    # Skip rules marked Not Applicable (e.g. user-dependent rules evaluated with no console user present)
+    not_applicable=$(/usr/libexec/PlistBuddy -c "Print $rule:not_applicable" $audit_plist 2>/dev/null)
+    if [[ $not_applicable == "true" ]]; then
+      continue
+    fi
     finding=$(/usr/libexec/PlistBuddy -c "Print $rule:finding" $audit_plist)
     if [[ $finding == "false" ]]; then
       compliant=$((compliant + 1))
@@ -289,10 +299,13 @@ generate_stats(){
 
 rule_fix(){
   local audit_score=$($plb -c "print $1:finding" $audit_plist)
+  local not_applicable=$($plb -c "print $1:not_applicable" $audit_plist 2>/dev/null)
   local exempt=$(/usr/bin/osascript -l JavaScript -e "ObjC.unwrap($.NSUserDefaults.alloc.initWithSuiteName('org.$baseline_name.audit').objectForKey('$1'))["exempt"]")
   local exempt_reason=$(/usr/bin/osascript -l JavaScript -e "ObjC.unwrap($.NSUserDefaults.alloc.initWithSuiteName('org.$baseline_name.audit').objectForKey('$1'))["exempt_reason"]")
 
-  if [[ ! $exempt == "1" ]] || [[ -z $exempt ]]; then
+  if [[ $not_applicable == "true" ]]; then
+    logmessage "$1 not_applicable - Requires a logged-in user, skipping remediation"
+  elif [[ ! $exempt == "1" ]] || [[ -z $exempt ]]; then
     if [[ $audit_score == "true" ]]; then
       ask "$1 - Run the command(s)-> $2" N
       if [[ $? == 0 ]]; then
@@ -317,8 +330,10 @@ run_scan(){
     logmessage "Beginning new compliance scan"
   fi
 
-  # run mcxrefresh
-  /usr/bin/mcxrefresh -u $CURR_USER_UID
+  # run mcxrefresh (only when a console user is present)
+  if [[ -n "$CURR_USER_UID" ]]; then
+    /usr/bin/mcxrefresh -u $CURR_USER_UID
+  fi
 
   # write timestamp of last compliance check
   /usr/bin/defaults write "$audit_plist" lastComplianceCheck "$timestamp"
@@ -362,8 +377,10 @@ run_fix(){
   # remove uchg on audit_control
   /usr/bin/chflags nouchg /etc/security/audit_control
 
-  # run mcxrefresh
-  /usr/bin/mcxrefresh -u $CURR_USER_UID
+  # run mcxrefresh (only when a console user is present)
+  if [[ -n "$CURR_USER_UID" ]]; then
+    /usr/bin/mcxrefresh -u $CURR_USER_UID
+  fi
 
   {% for profile in baseline.profile %}
   {% for rule in profile.rules %}


### PR DESCRIPTION
## Problem
Some rules can only be checked in the context of the logged-in user — their check uses `sudo -u "$CURRENT_USER" …` or reads `/Users/"$CURRENT_USER"/…`. When the script runs with **no one logged in** (at the login window, or an MDM scan before first login), there's no user to check against, so these rules can't actually be evaluated.

Today the script runs them anyway and reports misleading results:
- some come back as a **false pass** (it reads an empty/nonexistent path that happens to match the expected value), and
- some come back as a **false fail** while spraying `sudo` usage errors into the logs.

The architecture-mismatch path has a related gap: rules tagged for an architecture the machine isn't running (e.g. an `i386` rule on Apple Silicon) are logged as "does not apply" and written to the CSV as `N/A`, **but the audit plist gets a bare `finding = false`** with no flag — so downstream tooling counts them as compliant and the score is inflated.

Net effect: the compliance percentage is wrong and the logs are noisy. This change reports every "couldn't really evaluate this" case as **not applicable with a reason**, and leaves those rules out of the pass/fail tally.

## Fix
Rules referencing `$CURRENT_USER` / `$CURR_USER_UID` are detected at template-generation time and, when no console user is present at runtime, marked **Not Applicable** with a reason instead of evaluated. The existing architecture-mismatch path is unified to use the same signal.

- **`compliance_script.sh.jinja`**
  - Guard `CURR_USER_UID` against an empty/`root` console user so `id -u` can't misfire.
  - Gate both `mcxrefresh` calls behind a present uid.
  - Skip `not_applicable` rules in `compliance_count` (excluded from the tally) and in `rule_fix` (remediation skipped).
- **`check.jinja`**
  - For user-dependent rules, wrap the normal check in an `else`; when there's no console user, set `finding=NO`, `not_applicable=YES`, and `not_applicable_reason="Requires a logged-in user (no console user present)"`, and log it.
  - The normal evaluation path now writes `not_applicable=NO` to clear any stale flag from a prior logged-out scan.
  - **Unified the architecture-mismatch path** to the same signal: it now also writes `not_applicable=YES` + `not_applicable_reason="Does not apply to this architecture"` (previously it set only `finding=NO`).

### Data model
`not_applicable = true` + `not_applicable_reason` is now the single signal for "this rule wasn't evaluated," whatever the cause. `finding` keeps its existing meaning (`true` = failed, `false` = no finding) and stays `false` for N/A rules for backward compatibility. The rule for any consumer: **if `not_applicable` is true, ignore `finding` and show the reason.**

| Case | `finding` | `not_applicable` | `not_applicable_reason` |
|---|---|---|---|
| Evaluated, passed | false | false | — |
| Evaluated, failed | true | false | — |
| No console user | false | **true** | "Requires a logged-in user (no console user present)" |
| Wrong architecture | false | **true** | "Does not apply to this architecture" |

> **Note on keys:** `finding` already existed upstream. `not_applicable` / `not_applicable_reason` are new **plist keys** (`not_applicable_reason` mirrors the existing `exempt` / `exempt_reason` convention). The pre-existing `not_applicable` *rule tag* is a separate generation-time filter that excludes rules from the script entirely and is unaffected.
>
> **Note on control flow:** `run_scan()` has no runtime loop — the Jinja `{% for %}` unrolls rules sequentially at generation time — so the N/A branch uses an `if/else` wrapper, not `continue`/`return` (which would error or abort the remaining rules).

## Validation
Ran the **real generated compliance script** (`--check`) with `CURRENT_USER=""` (simulating the login window) on an Apple Silicon (`arm64`) machine, against a baseline exercising every path:
- `os_gatekeeper_enable` — not user-dependent (control)
- `os_firmware_password_require` — `i386`-tagged → architecture mismatch on arm64
- `system_settings_bluetooth_sharing_disable` — user-dependent (`sudo -u "$CURRENT_USER"`)
- `system_settings_hot_corners_secure` — user-dependent (`/Users/"$CURRENT_USER"/…`)

### Log file
**Before**
```
[INFO] Beginning new compliance scan
[INFO] os_gatekeeper_enable passed (Result: true, Expected: "true")
[INFO] os_firmware_password_require does not apply to this architecture
[INFO] system_settings_bluetooth_sharing_disable failed (Result: , Expected: "0")
[INFO] system_settings_hot_corners_secure passed (Result: 0, Expected: "0")
```
**After**
```
[INFO] Beginning new compliance scan
[INFO] os_gatekeeper_enable passed (Result: true, Expected: "true")
[INFO] os_firmware_password_require not_applicable - Does not apply to this architecture
[INFO] system_settings_bluetooth_sharing_disable not_applicable - Requires a logged-in user (no console user present)
[INFO] system_settings_hot_corners_secure not_applicable - Requires a logged-in user (no console user present)
```

### CSV
**Before**
```
Rule,Status,Result,Expected,Exemption
os_gatekeeper_enable,passed,true,true,
os_firmware_password_require,N/A,,,
system_settings_bluetooth_sharing_disable,failed,,0,
system_settings_hot_corners_secure,passed,0,0,
```
**After**
```
Rule,Status,Result,Expected,Exemption
os_gatekeeper_enable,passed,true,true,
os_firmware_password_require,N/A,,,Does not apply to this architecture
system_settings_bluetooth_sharing_disable,N/A,,,Requires a logged-in user (no console user present)
system_settings_hot_corners_secure,N/A,,,Requires a logged-in user (no console user present)
```

### Audit plist
**Before** — no `not_applicable` key anywhere; bluetooth recorded as a failure (`finding = true`); arch rule a bare `finding = false`:
```
os_gatekeeper_enable                       = { finding = false }
os_firmware_password_require               = { finding = false }
system_settings_bluetooth_sharing_disable  = { finding = true  }
system_settings_hot_corners_secure         = { finding = false }
```
**After** — uniform N/A signal with reasons; non-N/A rules just carry `not_applicable = false`:
```
os_gatekeeper_enable = {
    finding = false
    not_applicable = false
}
os_firmware_password_require = {
    finding = false
    not_applicable = true
    not_applicable_reason = Does not apply to this architecture
}
system_settings_bluetooth_sharing_disable = {
    finding = false
    not_applicable = true
    not_applicable_reason = Requires a logged-in user (no console user present)
}
system_settings_hot_corners_secure = {
    finding = false
    not_applicable = true
    not_applicable_reason = Requires a logged-in user (no console user present)
}
```

### Compliance stats (`--stats`)
| | Result |
|---|---|
| **Before** | `PASSED: 3  FAILED: 1` → **75%** — wrong on three counts: a false fail (bluetooth), a false pass (hot_corners), and the arch rule silently counted as compliant |
| **After**  | `PASSED: 1  FAILED: 0` → **100%** — only the one genuinely evaluable rule is counted |

### stderr (normally hidden by `run_scan`'s `2>/dev/null`)
**Before** — the empty `-u ""` makes `sudo` dump its usage block for every user-dependent rule, plus an `mcxrefresh` error:
```
usage: sudo -h | -K | -k | -V
usage: sudo -v [-ABkNnS] [-g group] [-h host] [-p prompt] [-u user]
usage: sudo -l [-ABkNnS] [-g group] [-h host] [-p prompt] [-U user] [-u user] [command [arg ...]]
usage: sudo [-ABbEHkNnPS] [-C num] [-D directory]
            [-g group] [-h host] [-p prompt] [-R directory] [-T timeout]
            [-u user] [VAR=value] [-i | -s] [command [arg ...]]
usage: sudo -e [-ABkNnS] [-C num] [-D directory] [-g group] [-h host] [-p prompt] [-R directory] [-T timeout] file ...
mcxrefresh[…] mcxrefresh- returned error status 1
```
**After** — no `sudo` usage error (the check is skipped) and no `mcxrefresh` error (gated behind a present uid). Behavior for non-user rules and logged-in scans is unchanged.

## Files changed
- `src/mscp/data/templates/shell_scripts/check.jinja`
- `src/mscp/data/templates/shell_scripts/compliance_script.sh.jinja`