### PR TITLE
Update to release strings and formatting, small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Civilian agencies are to use the National Checklist Program as required by [NIST
 
 ## Changelog
 
-Refer to the [CHANGELOG](CHANGELOG.md) for a complete list of changes.
+Refer to the [CHANGELOG](CHANGELOG.adoc) for a complete list of changes.
 
 ## NIST Disclaimer
 

--- a/src/mscp/common_utils/version_data.py
+++ b/src/mscp/common_utils/version_data.py
@@ -78,7 +78,7 @@ def get_version_data(
             )
         else:
             match["compliance_version"] = (
-                f"{OS_NAME_MAP.get(match['os_name'].lower(), match['os_name'])} Guidance, Revision {mscp_data['mscp'].get('version')}"
+                f"mSCP Release {mscp_data['mscp'].get('release')}"
             )
 
         return match

--- a/src/mscp/data/includes/mscp-data.yaml
+++ b/src/mscp/data/includes/mscp-data.yaml
@@ -3,7 +3,8 @@ mscp:
   version: '2.0'
   build: 30
   build_date: '2026-06-11'
-  release_date: '2026-12-12'
+  release_date: '2026-XX-XX'
+  release: '27.0'
 ddm:
   services:
     com.apple.bash: /etc/

--- a/src/mscp/data/rules/os/os_show_filename_extensions_enable.yaml
+++ b/src/mscp/data/rules/os/os_show_filename_extensions_enable.yaml
@@ -8,7 +8,7 @@ discussion: |
   The check and fix are for the currently logged in user. To get the currently logged in user, run the following.
   [source,bash]
   ----
-  CURRENT_USER=$( /usr/sbin/scutil <<< "show State:/Users/ConsoleUser" | /usr/bin/awk '/Name :/ && ! /loginwindow/ { print $3 }' )
+  CURRENT_USER=$( /usr/bin/defaults read /Library/Preferences/com.apple.loginwindow lastUserName )
   ----
   ====
 references:

--- a/src/mscp/data/templates/shell_scripts/compliance_script.sh.jinja
+++ b/src/mscp/data/templates/shell_scripts/compliance_script.sh.jinja
@@ -70,7 +70,7 @@ fi
 plb="/usr/libexec/PlistBuddy"
 
 # get the currently logged in user and hostname
-CURRENT_USER=$( /usr/sbin/scutil <<< "show State:/Users/ConsoleUser" | /usr/bin/awk '/Name :/ && ! /loginwindow/ { print $3 }')
+CURRENT_USER=$( /usr/bin/defaults read /Library/Preferences/com.apple.loginwindow lastUserName )
 CURR_USER_UID=$(/usr/bin/id -u $CURRENT_USER)
 CURR_HOSTNAME=$(/usr/sbin/scutil --get HostName)
 

--- a/src/mscp/data/templates/shell_scripts/compliance_script.sh.jinja
+++ b/src/mscp/data/templates/shell_scripts/compliance_script.sh.jinja
@@ -14,7 +14,7 @@
 #    
 #    MSCP COMPLIANCE SCRIPT BUILD INFORMATION
 #
-#    MSCP RELEASE: {{ mscp_release }}
+#    RELEASE: {{ mscp_release }}
 #    BASELINE: {{ baseline_name }}
 #    DATE: {{ todays_date }}
 #

--- a/src/mscp/data/templates/shell_scripts/restore_script.sh.jinja
+++ b/src/mscp/data/templates/shell_scripts/restore_script.sh.jinja
@@ -67,7 +67,7 @@ fi
 plb="/usr/libexec/PlistBuddy"
 
 # get the currently logged in user
-CURRENT_USER=$( /usr/sbin/scutil <<< "show State:/Users/ConsoleUser" | /usr/bin/awk '/Name :/ && ! /loginwindow/ { print $3 }')
+CURRENT_USER=$( /usr/bin/defaults read /Library/Preferences/com.apple.loginwindow lastUserName )
 CURR_USER_UID=$(/usr/bin/id -u $CURRENT_USER)
 
 # get system architecture

--- a/src/mscp/data/templates/shell_scripts/restore_script.sh.jinja
+++ b/src/mscp/data/templates/shell_scripts/restore_script.sh.jinja
@@ -14,7 +14,7 @@
 #    
 #    MSCP COMPLIANCE SCRIPT BUILD INFORMATION
 #
-#    MSCP RELEASE: {{ mscp_release }}
+#    RELEASE: {{ mscp_release }}
 #    BASELINE: {{ baseline_name }}
 #    DATE: {{ todays_date }}
 #    

--- a/src/mscp/generate/baseline.py
+++ b/src/mscp/generate/baseline.py
@@ -270,7 +270,7 @@ def generate_baseline(
     """
     sp.spinner = Spinners.dots
     if getattr(args, "migrate", None):
-        sp.text("Migrating baseline from 1.0")
+        sp.text = "Migrating baseline from legacy MSCP"
         migrate_legacy_baseline(args)
         return
 


### PR DESCRIPTION
Fixes the spinner text call that was breaking with baseline migrate.

Fixes the CURRENT_USER discovery mechanism.

Updates the release string and formatting.