### PR TITLE
fix: shell syntax for result

### DIFF
--- a/src/mscp/data/rules/os/os_httpd_disable.yaml
+++ b/src/mscp/data/rules/os/os_httpd_disable.yaml
@@ -90,9 +90,9 @@ platforms:
           if [[ -z "$running" ]] && [[ -z "$enabled" ]]; then
             result="PASS"
           elif [[ -n "$running" ]]; then
-            result=result+" RUNNING"
+            result="${result}  RUNNING"
           elif [[ -n "$enabled" ]]; then
-            result=result+" ENABLED"
+            result="${result}  ENABLED"
           fi
           echo $result
         result:

--- a/src/mscp/data/rules/os/os_tftpd_disable.yaml
+++ b/src/mscp/data/rules/os/os_tftpd_disable.yaml
@@ -99,9 +99,9 @@ platforms:
           if [[ -z "$running" ]] && [[ -z "$enabled" ]]; then
             result="PASS"
           elif [[ -n "$running" ]]; then
-            result=result+" RUNNING"
+            result="${result}  RUNNING"
           elif [[ -n "$enabled" ]]; then
-            result=result+" ENABLED"
+            result="${result}  ENABLED"
           fi
           echo $result
         result:

--- a/src/mscp/data/rules/os/os_uucp_disable.yaml
+++ b/src/mscp/data/rules/os/os_uucp_disable.yaml
@@ -83,9 +83,9 @@ platforms:
           if [[ -z "$running" ]] && [[ -z "$enabled" ]]; then
             result="PASS"
           elif [[ -n "$running" ]]; then
-            result=result+" RUNNING"
+            result="${result}  RUNNING"
           elif [[ -n "$enabled" ]]; then
-            result=result+" ENABLED"
+            result="${result}  ENABLED"
           fi
           echo $result
         result:

--- a/src/mscp/data/rules/system_settings/system_settings_screen_sharing_disable.yaml
+++ b/src/mscp/data/rules/system_settings/system_settings_screen_sharing_disable.yaml
@@ -101,9 +101,9 @@ platforms:
           if [[ -z "$running" ]] && [[ -z "$enabled" ]]; then
             result="PASS"
           elif [[ -n "$running" ]]; then
-            result=result+" RUNNING"
+            result="${result}  RUNNING"
           elif [[ -n "$enabled" ]]; then
-            result=result+" ENABLED"
+            result="${result}  ENABLED"
           fi
           echo $result
         result:

--- a/src/mscp/data/rules/system_settings/system_settings_ssh_disable.yaml
+++ b/src/mscp/data/rules/system_settings/system_settings_ssh_disable.yaml
@@ -77,9 +77,9 @@ platforms:
           if [[ -z "$running" ]] && [[ -z "$enabled" ]]; then
             result="PASS"
           elif [[ -n "$running" ]]; then
-            result=result+" RUNNING"
+            result="${result}  RUNNING"
           elif [[ -n "$enabled" ]]; then
-            result=result+" ENABLED"
+            result="${result}  ENABLED"
           fi
           echo $result
         result:


### PR DESCRIPTION
update the shell commands to correctly update the result value

Issue #744
Issue #745
Issue #746
Issue #747
Issue #748