### PR TITLE
Escape CSV fields in compliance script audit log (RFC 4180)

### DIFF
--- a/src/mscp/data/templates/shell_scripts/compliance_script.sh.jinja
+++ b/src/mscp/data/templates/shell_scripts/compliance_script.sh.jinja
@@ -116,6 +116,16 @@ logmessage(){
   fi
 }
 
+csv_escape(){
+  # Escape a field per RFC 4180: double any embedded double quotes, then wrap
+  # the whole field in double quotes so commas, quotes, CR and LF are literal.
+  local field="$1"
+  local quote='"'
+  field="${field//$quote/$quote$quote}"
+  field="$quote$field$quote"
+  printf '%s' "$field"
+}
+
 logcsv(){
   local rule_name="$1"
   local result_status="$2"
@@ -127,7 +137,7 @@ logcsv(){
     echo "Rule,Status,Result,Expected,Exemption" > "$audit_csv"
   fi
 
-  echo "$rule_name,$result_status,$result,$expected,$exemption" >> "$audit_csv"
+  echo "$(csv_escape "$rule_name"),$(csv_escape "$result_status"),$(csv_escape "$result"),$(csv_escape "$expected"),$(csv_escape "$exemption")" >> "$audit_csv"
 }
 
 ask() {

--- a/src/mscp/data/templates/shell_scripts/compliance_script.sh.jinja
+++ b/src/mscp/data/templates/shell_scripts/compliance_script.sh.jinja
@@ -134,10 +134,13 @@ logcsv(){
   local exemption="$5"
 
   if [[ ! -f "$audit_csv" ]]; then
-    echo "Rule,Status,Result,Expected,Exemption" > "$audit_csv"
+    printf '%s\n' "Rule,Status,Result,Expected,Exemption" > "$audit_csv"
   fi
 
-  echo "$(csv_escape "$rule_name"),$(csv_escape "$result_status"),$(csv_escape "$result"),$(csv_escape "$expected"),$(csv_escape "$exemption")" >> "$audit_csv"
+  # Use printf, not echo: under zsh `echo` interprets backslash escapes in the
+  # field values (e.g. an embedded `\c` truncates the line), which would corrupt
+  # the CSV even after csv_escape() has quoted each field.
+  printf '%s\n' "$(csv_escape "$rule_name"),$(csv_escape "$result_status"),$(csv_escape "$result"),$(csv_escape "$expected"),$(csv_escape "$exemption")" >> "$audit_csv"
 }
 
 ask() {


### PR DESCRIPTION
## Summary
`logcsv()` in the compliance script template writes the rule name, status,
result, expected, and exemption values straight into the audit CSV separated
by commas, with no escaping. Any field containing a comma, double quote, or
newline corrupts the file — shifting columns or breaking rows — so the audit
CSV can't be reliably parsed or opened in a spreadsheet app.

## Fix
- Add a `csv_escape()` helper that quotes each field and doubles embedded
  quotes, per RFC 4180.
- Route every `logcsv()` field through it.

## Impact
- Audit CSVs stay well-formed regardless of rule/result content.
- One file changed; no behavior change for values without special characters.
