### PR TITLE
Remove unused EOL sentinel assignment

### DIFF
--- a/src/mscp/data/templates/shell_scripts/compliance_script.sh.jinja
+++ b/src/mscp/data/templates/shell_scripts/compliance_script.sh.jinja
@@ -407,7 +407,6 @@ usage=(
     "                       2 - show minimal output"
   )
 
-set -- "$@" "${EOL:=$(printf '\1\3\3\7')}"
 
 # Look for managed arguments for compliance script
 if [[ $# -eq 0 ]];then
@@ -428,7 +427,7 @@ EOS
         set -- ${(z)compliance_args}
     fi
 fi
-  
+
 zparseopts -D -E -help=flag_help -check=check -fix=fix -stats=stats -compliant=compliant_opt -non_compliant=non_compliant_opt -reset=reset -reset-all=reset_all -cfc=cfc -quiet:=quiet || { print -l $usage && return }
 
 [[ -z "$flag_help" ]] || { print -l $usage && return }

--- a/src/mscp/data/templates/shell_scripts/restore_script.sh.jinja
+++ b/src/mscp/data/templates/shell_scripts/restore_script.sh.jinja
@@ -194,7 +194,7 @@ usage=(
     "--rule <rule_id>   :   restore default state for rule_id"
   )
 
-set -- "$@" "${EOL:=$(printf '\1\3\3\7')}"
+# set -- "$@" "${EOL:=$(printf '\1\3\3\7')}"
 
 # Look for managed arguments for compliance script
 if [[ $# -eq 0 ]];then


### PR DESCRIPTION
Removed set -- "$@" "${EOL:=$(printf '\1\3\3\7')}" so managed arguments execute for the compliance script.

Unnecessary line. This reset the parameters wiping out potential managed arguments.