### PR TITLE
STIGID updated for macos 27.

### DIFF
--- a/src/mscp/data/rules/audit/audit_acls_files_configure.yaml
+++ b/src/mscp/data/rules/audit/audit_acls_files_configure.yaml
@@ -36,6 +36,8 @@ references:
       - SRG-OS-000258-GPOS-00099
       - SRG-OS-000058-GPOS-00028
     disa_stig:
+      macos_27:
+        - APPL-27-000030
       macos_26:
         - APPL-26-000030
       macos_15:
@@ -60,7 +62,10 @@ references:
       - 3.3
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/audit/audit_acls_folders_configure.yaml
+++ b/src/mscp/data/rules/audit/audit_acls_folders_configure.yaml
@@ -35,7 +35,9 @@ references:
       - SRG-OS-000257-GPOS-00098
       - SRG-OS-000258-GPOS-00099
       - SRG-OS-000058-GPOS-00028
-    disa_stig:
+    disa_stig:      
+      macos_27:
+        - APPL-27-000031
       macos_26:
         - APPL-26-000031
       macos_15:
@@ -60,7 +62,10 @@ references:
       - 3.3
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/audit/audit_auditd_enabled.yaml
+++ b/src/mscp/data/rules/audit/audit_auditd_enabled.yaml
@@ -89,6 +89,8 @@ references:
       - SRG-OS-000055-GPOS-00026
       - SRG-OS-000755-GPOS-00220
     disa_stig:
+      macos_27:
+        - APPL-27-001003
       macos_26:
         - APPL-26-001003
       macos_15:
@@ -118,7 +120,10 @@ references:
       - 8.5
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/audit/audit_configure_capacity_notify.yaml
+++ b/src/mscp/data/rules/audit/audit_configure_capacity_notify.yaml
@@ -25,6 +25,8 @@ references:
       - SRG-OS-000046-GPOS-00022
       - SRG-OS-000343-GPOS-00134
     disa_stig:
+      macos_27:
+        - APPL-27-001030
       macos_26:
         - APPL-26-001030
       macos_15:
@@ -33,7 +35,10 @@ references:
         - APPL-14-001030
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: low
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/audit/audit_control_acls_configure.yaml
+++ b/src/mscp/data/rules/audit/audit_control_acls_configure.yaml
@@ -35,6 +35,8 @@ references:
       - SRG-OS-000258-GPOS-00099
       - SRG-OS-000058-GPOS-00028
     disa_stig:
+      macos_27:
+        - APPL-27-001140
       macos_26:
         - APPL-26-001140
       macos_15:
@@ -59,7 +61,10 @@ references:
       - 3.3
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/audit/audit_control_group_configure.yaml
+++ b/src/mscp/data/rules/audit/audit_control_group_configure.yaml
@@ -35,6 +35,8 @@ references:
       - SRG-OS-000258-GPOS-00099
       - SRG-OS-000058-GPOS-00028
     disa_stig:
+      macos_27:
+        - APPL-27-001110
       macos_26:
         - APPL-26-001110
       macos_15:
@@ -59,7 +61,10 @@ references:
       - 3.3
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/audit/audit_control_mode_configure.yaml
+++ b/src/mscp/data/rules/audit/audit_control_mode_configure.yaml
@@ -35,6 +35,8 @@ references:
       - SRG-OS-000258-GPOS-00099
       - SRG-OS-000058-GPOS-00028
     disa_stig:
+      macos_27:
+        - APPL-27-001130
       macos_26:
         - APPL-26-001130
       macos_15:
@@ -59,7 +61,10 @@ references:
       - 3.3
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/audit/audit_control_owner_configure.yaml
+++ b/src/mscp/data/rules/audit/audit_control_owner_configure.yaml
@@ -35,6 +35,8 @@ references:
       - SRG-OS-000258-GPOS-00099
       - SRG-OS-000058-GPOS-00028
     disa_stig:
+      macos_27:
+        - APPL-27-001120
       macos_26:
         - APPL-26-001120
       macos_15:
@@ -59,7 +61,10 @@ references:
       - 3.3
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/audit/audit_files_group_configure.yaml
+++ b/src/mscp/data/rules/audit/audit_files_group_configure.yaml
@@ -37,6 +37,8 @@ references:
       - SRG-OS-000258-GPOS-00099
       - SRG-OS-000058-GPOS-00028
     disa_stig:
+      macos_27:
+        - APPL-27-001014
       macos_26:
         - APPL-26-001014
       macos_15:
@@ -61,7 +63,10 @@ references:
       - 3.3
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/audit/audit_files_mode_configure.yaml
+++ b/src/mscp/data/rules/audit/audit_files_mode_configure.yaml
@@ -33,6 +33,8 @@ references:
       - SRG-OS-000258-GPOS-00099
       - SRG-OS-000058-GPOS-00028
     disa_stig:
+      macos_27:
+        - APPL-27-001016
       macos_26:
         - APPL-26-001016
       macos_15:
@@ -57,7 +59,10 @@ references:
       - 3.3
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/audit/audit_files_owner_configure.yaml
+++ b/src/mscp/data/rules/audit/audit_files_owner_configure.yaml
@@ -37,6 +37,8 @@ references:
       - SRG-OS-000258-GPOS-00099
       - SRG-OS-000058-GPOS-00028
     disa_stig:
+      macos_27:
+        - APPL-27-001012
       macos_26:
         - APPL-26-001012
       macos_15:
@@ -61,7 +63,10 @@ references:
       - 3.3
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/audit/audit_flags_aa_configure.yaml
+++ b/src/mscp/data/rules/audit/audit_flags_aa_configure.yaml
@@ -46,6 +46,8 @@ references:
       - SRG-OS-000458-GPOS-00203
       - SRG-OS-000468-GPOS-00212
     disa_stig:
+      macos_27:
+        - APPL-27-001044
       macos_26:
         - APPL-26-001044
       macos_15:
@@ -75,7 +77,10 @@ references:
       - 8.5
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl2

--- a/src/mscp/data/rules/audit/audit_flags_ad_configure.yaml
+++ b/src/mscp/data/rules/audit/audit_flags_ad_configure.yaml
@@ -64,6 +64,8 @@ references:
       - SRG-OS-000303-GPOS-00120
       - SRG-OS-000755-GPOS-00220
     disa_stig:
+      macos_27:
+        - APPL-27-001001
       macos_26:
         - APPL-26-001001
       macos_15:
@@ -96,7 +98,10 @@ references:
       - 8.5
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl2

--- a/src/mscp/data/rules/audit/audit_flags_ex_configure.yaml
+++ b/src/mscp/data/rules/audit/audit_flags_ex_configure.yaml
@@ -37,6 +37,8 @@ references:
       - SRG-OS-000458-GPOS-00203
       - SRG-OS-000463-GPOS-00207
     disa_stig:
+      macos_27:
+        - APPL-27-001024
       macos_26:
         - APPL-26-001024
       macos_15:
@@ -65,7 +67,10 @@ references:
       - 8.5
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl2

--- a/src/mscp/data/rules/audit/audit_flags_fd_configure.yaml
+++ b/src/mscp/data/rules/audit/audit_flags_fd_configure.yaml
@@ -59,6 +59,8 @@ references:
       - SRG-OS-000458-GPOS-00203
       - SRG-OS-000058-GPOS-00028
     disa_stig:
+      macos_27:
+        - APPL-27-001020
       macos_26:
         - APPL-26-001020
       macos_15:
@@ -76,7 +78,10 @@ references:
       - 8.L.A
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/audit/audit_flags_fm_configure.yaml
+++ b/src/mscp/data/rules/audit/audit_flags_fm_configure.yaml
@@ -60,6 +60,8 @@ references:
       - SRG-OS-000458-GPOS-00203
       - SRG-OS-000058-GPOS-00028
     disa_stig:
+      macos_27:
+        - APPL-27-001021
       macos_26:
         - APPL-26-001021
       macos_15:
@@ -77,7 +79,10 @@ references:
       - 8.L.A
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/audit/audit_flags_fr_configure.yaml
+++ b/src/mscp/data/rules/audit/audit_flags_fr_configure.yaml
@@ -51,6 +51,8 @@ references:
       - SRG-OS-000458-GPOS-00203
       - SRG-OS-000058-GPOS-00028
     disa_stig:
+      macos_27:
+        - APPL-27-001022
       macos_26:
         - APPL-26-001022
       macos_15:
@@ -80,7 +82,10 @@ references:
       - 8.5
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl2

--- a/src/mscp/data/rules/audit/audit_flags_fw_configure.yaml
+++ b/src/mscp/data/rules/audit/audit_flags_fw_configure.yaml
@@ -52,6 +52,8 @@ references:
       - SRG-OS-000458-GPOS-00203
       - SRG-OS-000058-GPOS-00028
     disa_stig:
+      macos_27:
+        - APPL-27-001023
       macos_26:
         - APPL-26-001023
       macos_15:
@@ -81,7 +83,10 @@ references:
       - 8.5
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl2

--- a/src/mscp/data/rules/audit/audit_flags_lo_configure.yaml
+++ b/src/mscp/data/rules/audit/audit_flags_lo_configure.yaml
@@ -43,6 +43,8 @@ references:
       - SRG-OS-000458-GPOS-00203
       - SRG-OS-000755-GPOS-00220
     disa_stig:
+      macos_27:
+        - APPL-27-001002
       macos_26:
         - APPL-26-001002
       macos_15:
@@ -72,7 +74,10 @@ references:
       - 8.5
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl2

--- a/src/mscp/data/rules/audit/audit_folder_group_configure.yaml
+++ b/src/mscp/data/rules/audit/audit_folder_group_configure.yaml
@@ -37,6 +37,8 @@ references:
       - SRG-OS-000258-GPOS-00099
       - SRG-OS-000058-GPOS-00028
     disa_stig:
+      macos_27:
+        - APPL-27-001015
       macos_26:
         - APPL-26-001015
       macos_15:
@@ -61,7 +63,10 @@ references:
       - 3.3
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/audit/audit_folder_owner_configure.yaml
+++ b/src/mscp/data/rules/audit/audit_folder_owner_configure.yaml
@@ -37,6 +37,8 @@ references:
       - SRG-OS-000258-GPOS-00099
       - SRG-OS-000058-GPOS-00028
     disa_stig:
+      macos_27:
+        - APPL-27-001013
       macos_26:
         - APPL-26-001013
       macos_15:
@@ -61,7 +63,10 @@ references:
       - 3.3
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/audit/audit_folders_mode_configure.yaml
+++ b/src/mscp/data/rules/audit/audit_folders_mode_configure.yaml
@@ -35,6 +35,8 @@ references:
       - SRG-OS-000258-GPOS-00099
       - SRG-OS-000058-GPOS-00028
     disa_stig:
+      macos_27:
+        - APPL-27-001017
       macos_26:
         - APPL-26-001017
       macos_15:
@@ -59,7 +61,10 @@ references:
       - 3.3
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/audit/audit_retention_configure.yaml
+++ b/src/mscp/data/rules/audit/audit_retention_configure.yaml
@@ -26,6 +26,8 @@ references:
     srg:
       - SRG-OS-000341-GPOS-00132
     disa_stig:
+      macos_27:
+        - APPL-27-001029
       macos_26:
         - APPL-26-001029
       macos_15:
@@ -51,7 +53,10 @@ references:
       - 8.3
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: low
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/audit/audit_settings_failure_notify.yaml
+++ b/src/mscp/data/rules/audit/audit_settings_failure_notify.yaml
@@ -28,6 +28,8 @@ references:
       - SRG-OS-000047-GPOS-00023
       - SRG-OS-000344-GPOS-00135
     disa_stig:
+      macos_27:
+        - APPL-27-001031
       macos_26:
         - APPL-26-001031
       macos_15:
@@ -38,7 +40,10 @@ references:
       - AU.L2-3.3.4
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/auth/auth_pam_login_smartcard_enforce.yaml
+++ b/src/mscp/data/rules/auth/auth_pam_login_smartcard_enforce.yaml
@@ -42,6 +42,8 @@ references:
       - SRG-OS-000105-GPOS-00052
       - SRG-OS-000705-GPOS-00150
     disa_stig:
+      macos_27:
+        - APPL-27-003050
       macos_26:
         - APPL-26-003050
       macos_15:
@@ -62,7 +64,10 @@ references:
       - 6.5
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/auth/auth_pam_su_smartcard_enforce.yaml
+++ b/src/mscp/data/rules/auth/auth_pam_su_smartcard_enforce.yaml
@@ -42,6 +42,8 @@ references:
       - SRG-OS-000105-GPOS-00052
       - SRG-OS-000705-GPOS-00150
     disa_stig:
+      macos_27:
+        - APPL-27-003051
       macos_26:
         - APPL-26-003051
       macos_15:
@@ -61,7 +63,10 @@ references:
       - 6.5
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/auth/auth_pam_sudo_smartcard_enforce.yaml
+++ b/src/mscp/data/rules/auth/auth_pam_sudo_smartcard_enforce.yaml
@@ -42,6 +42,8 @@ references:
       - SRG-OS-000105-GPOS-00052
       - SRG-OS-000705-GPOS-00150
     disa_stig:
+      macos_27:
+        - APPL-27-003052
       macos_26:
         - APPL-26-003052
       macos_15:
@@ -61,7 +63,10 @@ references:
       - 6.5
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/auth/auth_smartcard_allow.yaml
+++ b/src/mscp/data/rules/auth/auth_smartcard_allow.yaml
@@ -41,6 +41,8 @@ references:
       - SRG-OS-000105-GPOS-00052
       - SRG-OS-000068-GPOS-00036
     disa_stig:
+      macos_27:
+        - APPL-27-003030
       macos_26:
         - APPL-26-003030
       macos_15:
@@ -62,7 +64,10 @@ references:
       - 6.5
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/auth/auth_smartcard_certificate_trust_enforce_moderate.yaml
+++ b/src/mscp/data/rules/auth/auth_smartcard_certificate_trust_enforce_moderate.yaml
@@ -36,6 +36,8 @@ references:
       - SRG-OS-000377-GPOS-00162
       - SRG-OS-000066-GPOS-00034
     disa_stig:
+      macos_27:
+        - APPL-27-001060
       macos_26:
         - APPL-26-001060
       macos_15:
@@ -50,7 +52,10 @@ references:
       - 3.L.C
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/auth/auth_smartcard_enforce.yaml
+++ b/src/mscp/data/rules/auth/auth_smartcard_enforce.yaml
@@ -55,6 +55,8 @@ references:
       - SRG-OS-000105-GPOS-00052
       - SRG-OS-000705-GPOS-00150
     disa_stig:
+      macos_27:
+        - APPL-27-003020
       macos_26:
         - APPL-26-003020
       macos_15:
@@ -77,7 +79,10 @@ references:
       - 6.5
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/auth/auth_ssh_password_authentication_disable.yaml
+++ b/src/mscp/data/rules/auth/auth_ssh_password_authentication_disable.yaml
@@ -51,6 +51,8 @@ references:
       - SRG-OS-000375-GPOS-00160
       - SRG-OS-000105-GPOS-00052
     disa_stig:
+      macos_27:
+        - APPL-27-001150
       macos_26:
         - APPL-26-001150
       macos_15:
@@ -74,7 +76,10 @@ references:
       - 6.5
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: high
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/icloud/icloud_addressbook_disable.yaml
+++ b/src/mscp/data/rules/icloud/icloud_addressbook_disable.yaml
@@ -33,6 +33,8 @@ references:
     srg:
       - SRG-OS-000095-GPOS-00049
     disa_stig:
+      macos_27:
+        - APPL-27-002014
       macos_26:
         - APPL-26-002014
       macos_15:
@@ -55,7 +57,10 @@ references:
       - 15.3
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/icloud/icloud_bookmarks_disable.yaml
+++ b/src/mscp/data/rules/icloud/icloud_bookmarks_disable.yaml
@@ -33,6 +33,8 @@ references:
     srg:
       - SRG-OS-000095-GPOS-00049
     disa_stig:
+      macos_27:
+        - APPL-27-002042
       macos_26:
         - APPL-26-002042
       macos_15:
@@ -55,7 +57,10 @@ references:
       - 15.3
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/icloud/icloud_calendar_disable.yaml
+++ b/src/mscp/data/rules/icloud/icloud_calendar_disable.yaml
@@ -33,6 +33,8 @@ references:
     srg:
       - SRG-OS-000095-GPOS-00049
     disa_stig:
+      macos_27:
+        - APPL-27-002012    
       macos_26:
         - APPL-26-002012
       macos_15:
@@ -55,7 +57,10 @@ references:
       - 15.3
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/icloud/icloud_drive_disable.yaml
+++ b/src/mscp/data/rules/icloud/icloud_drive_disable.yaml
@@ -46,7 +46,9 @@ references:
       - CCI-001774
     srg:
       - SRG-OS-000095-GPOS-00049
-    disa_stig:
+    disa_stig:      
+      macos_27:
+        - APPL-27-002041
       macos_26:
         - APPL-26-002041
       macos_15:
@@ -99,7 +101,10 @@ references:
         - ANNEX K
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/icloud/icloud_freeform_disable.yaml
+++ b/src/mscp/data/rules/icloud/icloud_freeform_disable.yaml
@@ -33,6 +33,8 @@ references:
     srg:
       - SRG-OS-000095-GPOS-00049
     disa_stig:
+      macos_27:
+        - APPL-27-002270    
       macos_26:
         - APPL-26-002270
       macos_15:
@@ -55,7 +57,10 @@ references:
       - 15.3
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/icloud/icloud_game_center_disable.yaml
+++ b/src/mscp/data/rules/icloud/icloud_game_center_disable.yaml
@@ -32,6 +32,8 @@ references:
     srg:
       - SRG-OS-000095-GPOS-00049
     disa_stig:
+      macos_27:
+        - APPL-27-002160
       macos_26:
         - APPL-26-002160
       macos_15:
@@ -54,7 +56,10 @@ references:
       - 15.3
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/icloud/icloud_keychain_disable.yaml
+++ b/src/mscp/data/rules/icloud/icloud_keychain_disable.yaml
@@ -45,6 +45,8 @@ references:
     srg:
       - SRG-OS-000095-GPOS-00049
     disa_stig:
+      macos_27:
+        - APPL-27-002040
       macos_26:
         - APPL-26-002040
       macos_15:
@@ -98,7 +100,10 @@ references:
         - ANNEX K
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/icloud/icloud_mail_disable.yaml
+++ b/src/mscp/data/rules/icloud/icloud_mail_disable.yaml
@@ -33,6 +33,8 @@ references:
     srg:
       - SRG-OS-000095-GPOS-00049
     disa_stig:
+      macos_27:
+        - APPL-27-002015
       macos_26:
         - APPL-26-002015
       macos_15:
@@ -55,7 +57,10 @@ references:
       - 15.3
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/icloud/icloud_notes_disable.yaml
+++ b/src/mscp/data/rules/icloud/icloud_notes_disable.yaml
@@ -33,6 +33,8 @@ references:
     srg:
       - SRG-OS-000095-GPOS-00049
     disa_stig:
+      macos_27:
+        - APPL-27-002016
       macos_26:
         - APPL-26-002016
       macos_15:
@@ -55,7 +57,10 @@ references:
       - 15.3
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/icloud/icloud_photos_disable.yaml
+++ b/src/mscp/data/rules/icloud/icloud_photos_disable.yaml
@@ -45,6 +45,8 @@ references:
     srg:
       - SRG-OS-000095-GPOS-00049
     disa_stig:
+      macos_27:
+        - APPL-27-002043
       macos_26:
         - APPL-26-002043
       macos_15:
@@ -89,7 +91,10 @@ references:
         - ANNEX K
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/icloud/icloud_private_relay_disable.yaml
+++ b/src/mscp/data/rules/icloud/icloud_private_relay_disable.yaml
@@ -34,6 +34,8 @@ references:
     srg:
       - SRG-OS-000095-GPOS-00049
     disa_stig:
+      macos_27:
+        - APPL-27-002170
       macos_26:
         - APPL-26-002170
       macos_15:
@@ -55,7 +57,10 @@ references:
       - 15.3
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/icloud/icloud_reminders_disable.yaml
+++ b/src/mscp/data/rules/icloud/icloud_reminders_disable.yaml
@@ -33,6 +33,8 @@ references:
     srg:
       - SRG-OS-000095-GPOS-00049
     disa_stig:
+      macos_27:
+        - APPL-27-002013
       macos_26:
         - APPL-26-002013
       macos_15:
@@ -55,7 +57,10 @@ references:
       - 15.3
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/icloud/icloud_sync_disable.yaml
+++ b/src/mscp/data/rules/icloud/icloud_sync_disable.yaml
@@ -32,6 +32,8 @@ references:
     srg:
       - SRG-OS-000095-GPOS-00049
     disa_stig:
+      macos_27:
+        - APPL-27-002150
       macos_26:
         - APPL-26-002150
       macos_15:
@@ -65,7 +67,10 @@ references:
       - 15.3
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl2

--- a/src/mscp/data/rules/os/os_account_modification_disable.yaml
+++ b/src/mscp/data/rules/os/os_account_modification_disable.yaml
@@ -48,6 +48,8 @@ references:
     srg:
       - SRG-OS-000095-GPOS-00049
     disa_stig:
+      macos_27:
+        - APPL-27-002120
       macos_26:
         - APPL-26-002120
       macos_15:
@@ -78,7 +80,10 @@ references:
         - ANNEX K
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/os/os_airdrop_disable.yaml
+++ b/src/mscp/data/rules/os/os_airdrop_disable.yaml
@@ -45,6 +45,8 @@ references:
       - SRG-OS-000080-GPOS-00048
       - SRG-OS-000095-GPOS-00049
     disa_stig:
+      macos_27:
+        - APPL-27-002009
       macos_26:
         - APPL-26-002009
       macos_15:
@@ -94,7 +96,10 @@ references:
         - ANNEX K
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/os/os_apple_intelligence_pcc_disable.yaml
+++ b/src/mscp/data/rules/os/os_apple_intelligence_pcc_disable.yaml
@@ -30,6 +30,9 @@ references:
       - CCI-001774
     srg:
       - SRG-OS-000095-GPOS-00049
+    disa_stig:
+      macos_27:
+        - APPL-27-005180
     cmmc:
       - AC.L1-3.1.20
       - CM.L2-3.4.6
@@ -46,7 +49,10 @@ references:
       - 15.3
 platforms:
   macOS:
-    '27.0': {}    
+    '27.0':    
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     enforcement_info:
       check:
         shell: |-

--- a/src/mscp/data/rules/os/os_appleid_prompt_disable.yaml
+++ b/src/mscp/data/rules/os/os_appleid_prompt_disable.yaml
@@ -25,6 +25,8 @@ references:
     srg:
       - SRG-OS-000095-GPOS-00049
     disa_stig:
+      macos_27:
+        - APPL-27-002035
       macos_26:
         - APPL-26-002035
       macos_15:
@@ -39,7 +41,10 @@ references:
       - 4.8
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/os/os_asl_log_files_owner_group_configure.yaml
+++ b/src/mscp/data/rules/os/os_asl_log_files_owner_group_configure.yaml
@@ -25,6 +25,8 @@ references:
       - SRG-OS-000206-GPOS-00084
       - SRG-OS-000205-GPOS-00083
     disa_stig:
+      macos_27:
+        - APPL-27-004001
       macos_26:
         - APPL-26-004001
       macos_15:
@@ -33,7 +35,10 @@ references:
         - APPL-14-004001
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/os/os_asl_log_files_permissions_configure.yaml
+++ b/src/mscp/data/rules/os/os_asl_log_files_permissions_configure.yaml
@@ -23,6 +23,8 @@ references:
       - SRG-OS-000206-GPOS-00084
       - SRG-OS-000205-GPOS-00083
     disa_stig:
+      macos_27:
+        - APPL-27-004002
       macos_26:
         - APPL-26-004002
       macos_15:
@@ -31,7 +33,10 @@ references:
         - APPL-14-004002
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/os/os_authenticated_root_enable.yaml
+++ b/src/mscp/data/rules/os/os_authenticated_root_enable.yaml
@@ -35,6 +35,8 @@ references:
     srg:
       - SRG-OS-000080-GPOS-00048
     disa_stig:
+      macos_27:
+        - APPL-27-005070
       macos_26:
         - APPL-26-005070
       macos_15:
@@ -68,7 +70,10 @@ references:
       - 3.11
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/os/os_bonjour_disable.yaml
+++ b/src/mscp/data/rules/os/os_bonjour_disable.yaml
@@ -24,6 +24,8 @@ references:
     srg:
       - SRG-OS-000095-GPOS-00049
     disa_stig:
+      macos_27:
+        - APPL-27-002005
       macos_26:
         - APPL-26-002005
       macos_15:
@@ -50,7 +52,10 @@ references:
       - 4.8
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl2

--- a/src/mscp/data/rules/os/os_camera_disable.yaml
+++ b/src/mscp/data/rules/os/os_camera_disable.yaml
@@ -40,6 +40,8 @@ references:
     srg:
       - SRG-OS-000095-GPOS-00049
     disa_stig:
+      macos_27:
+        - APPL-27-002017
       macos_26:
         - APPL-26-002017
       macos_15:
@@ -50,7 +52,10 @@ references:
         - AIOS-26-018100
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/os/os_certificate_authority_trust.yaml
+++ b/src/mscp/data/rules/os/os_certificate_authority_trust.yaml
@@ -25,6 +25,8 @@ references:
       - SRG-OS-000403-GPOS-00182
       - SRG-OS-000775-GPOS-00230
     disa_stig:
+      macos_27:
+        - APPL-27-003001
       macos_26:
         - APPL-26-003001
       macos_15:
@@ -39,7 +41,10 @@ references:
       - 3.L.C
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: high
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/os/os_config_data_install_enforce.yaml
+++ b/src/mscp/data/rules/os/os_config_data_install_enforce.yaml
@@ -30,6 +30,8 @@ references:
     srg:
       - SRG-OS-000480-GPOS-00227
     disa_stig:
+      macos_27:
+        - APPL-27-005130
       macos_26:
         - APPL-26-005130
       macos_15:
@@ -61,7 +63,10 @@ references:
       - 8.19.01
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/os/os_erase_contents_and_settings_disable.yaml
+++ b/src/mscp/data/rules/os/os_erase_contents_and_settings_disable.yaml
@@ -39,6 +39,8 @@ references:
       - SRG-OS-000480-GPOS-00227
       - SRG-OS-000095-GPOS-00049      
     disa_stig:
+      macos_27:
+        - APPL-27-005061
       macos_26:
         - APPL-26-005061
       macos_15:
@@ -76,7 +78,10 @@ references:
       - 2.L.A      
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/os/os_facetime_app_disable.yaml
+++ b/src/mscp/data/rules/os/os_facetime_app_disable.yaml
@@ -37,6 +37,8 @@ references:
     srg:
       - SRG-OS-000095-GPOS-00049
     disa_stig:
+      macos_27:
+        - APPL-27-002010
       macos_26:
         - APPL-26-002010
       macos_15:
@@ -56,7 +58,10 @@ references:
       - 4.8
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/os/os_filevault_autologin_disable.yaml
+++ b/src/mscp/data/rules/os/os_filevault_autologin_disable.yaml
@@ -30,6 +30,8 @@ references:
     srg:
       - SRG-OS-000080-GPOS-00048
     disa_stig:
+      macos_27:
+        - APPL-27-000033
       macos_26:
         - APPL-26-000033
       macos_15:
@@ -44,7 +46,10 @@ references:
       - 6.7
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/os/os_gatekeeper_enable.yaml
+++ b/src/mscp/data/rules/os/os_gatekeeper_enable.yaml
@@ -33,6 +33,8 @@ references:
       - SRG-OS-000366-GPOS-00153
       - SRG-OS-000480-GPOS-00228
     disa_stig:
+      macos_27:
+        - APPL-27-002064
       macos_26:
         - APPL-26-002064
       macos_15:
@@ -69,7 +71,10 @@ references:
       - 10.5
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: high
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/os/os_genmoji_disable.yaml
+++ b/src/mscp/data/rules/os/os_genmoji_disable.yaml
@@ -33,6 +33,8 @@ references:
     srg:
       - SRG-OS-000095-GPOS-00049
     disa_stig:
+      macos_27:
+        - APPL-27-005140
       macos_26:
         - APPL-26-005140
       macos_15:
@@ -51,7 +53,10 @@ references:
       - 2.L.A
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/os/os_handoff_disable.yaml
+++ b/src/mscp/data/rules/os/os_handoff_disable.yaml
@@ -46,6 +46,8 @@ references:
       - SRG-OS-000080-GPOS-00048
       - SRG-OS-000095-GPOS-00049
     disa_stig:
+      macos_27:
+        - APPL-27-005058
       macos_26:
         - APPL-26-005058
       macos_15:
@@ -94,7 +96,10 @@ references:
         - ANNEX K
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/os/os_home_folders_secure.yaml
+++ b/src/mscp/data/rules/os/os_home_folders_secure.yaml
@@ -26,6 +26,8 @@ references:
       - SRG-OS-000480-GPOS-00230
       - SRG-OS-000480-GPOS-00228
     disa_stig:
+      macos_27:
+        - APPL-27-002068
       macos_26:
         - APPL-26-002068
       macos_15:
@@ -57,7 +59,10 @@ references:
       - 3.3
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/os/os_httpd_disable.yaml
+++ b/src/mscp/data/rules/os/os_httpd_disable.yaml
@@ -27,6 +27,8 @@ references:
     srg:
       - SRG-OS-000080-GPOS-00048
     disa_stig:
+      macos_27:
+        - APPL-27-002008
       macos_26:
         - APPL-26-002008
       macos_15:
@@ -55,7 +57,10 @@ references:
       - 4.8
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/os/os_icloud_storage_prompt_disable.yaml
+++ b/src/mscp/data/rules/os/os_icloud_storage_prompt_disable.yaml
@@ -26,6 +26,8 @@ references:
     srg:
       - SRG-OS-000095-GPOS-00049
     disa_stig:
+      macos_27:
+        - APPL-27-002037
       macos_26:
         - APPL-26-002037
       macos_15:
@@ -40,7 +42,10 @@ references:
       - 4.8
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/os/os_image_playground_disable.yaml
+++ b/src/mscp/data/rules/os/os_image_playground_disable.yaml
@@ -36,6 +36,8 @@ references:
     srg:
       - SRG-OS-000095-GPOS-00049
     disa_stig:
+      macos_27:
+        - APPL-27-005150
       macos_26:
         - APPL-26-005150
       macos_15:
@@ -55,7 +57,9 @@ references:
       - 2.L.A
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/os/os_install_log_retention_configure.yaml
+++ b/src/mscp/data/rules/os/os_install_log_retention_configure.yaml
@@ -24,6 +24,8 @@ references:
     srg:
       - SRG-OS-000341-GPOS-00132
     disa_stig:
+      macos_27:
+        - APPL-27-004050
       macos_26:
         - APPL-26-004050
       macos_15:
@@ -49,7 +51,10 @@ references:
       - 8.3
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/os/os_iphone_mirroring_disable.yaml
+++ b/src/mscp/data/rules/os/os_iphone_mirroring_disable.yaml
@@ -36,6 +36,8 @@ references:
       - SRG-OS-000080-GPOS-00048
       - SRG-OS-000095-GPOS-00049
     disa_stig:
+      macos_27:
+        - APPL-27-002271
       macos_26:
         - APPL-26-002271
       macos_15:
@@ -70,7 +72,10 @@ references:
       - 8.12
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/os/os_loginwindow_adminhostinfo_disabled.yaml
+++ b/src/mscp/data/rules/os/os_loginwindow_adminhostinfo_disabled.yaml
@@ -23,11 +23,16 @@ references:
     srg:
       - SRG-OS-000031-GPOS-00012
     disa_stig:
+      macos_277:
+        - APPL-27-000009
       macos_26:
         - APPL-26-000009
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/os/os_mdm_require.yaml
+++ b/src/mscp/data/rules/os/os_mdm_require.yaml
@@ -40,6 +40,8 @@ references:
     srg:
       - SRG-OS-000480-GPOS-00227
     disa_stig:
+      macos_27:
+        - APPL-27-005110
       macos_26:
         - APPL-26-005110
       macos_15:
@@ -68,7 +70,10 @@ references:
       - 5.1
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/os/os_newsyslog_files_owner_group_configure.yaml
+++ b/src/mscp/data/rules/os/os_newsyslog_files_owner_group_configure.yaml
@@ -25,6 +25,8 @@ references:
       - SRG-OS-000206-GPOS-00084
       - SRG-OS-000205-GPOS-00083
     disa_stig:
+      macos_27:
+        - APPL-27-004030
       macos_26:
         - APPL-26-004030
       macos_15:
@@ -33,7 +35,10 @@ references:
         - APPL-14-004030
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/os/os_newsyslog_files_permissions_configure.yaml
+++ b/src/mscp/data/rules/os/os_newsyslog_files_permissions_configure.yaml
@@ -23,6 +23,8 @@ references:
       - SRG-OS-000206-GPOS-00084
       - SRG-OS-000205-GPOS-00083
     disa_stig:
+      macos_27:
+        - APPL-27-004040
       macos_26:
         - APPL-26-004040
       macos_15:
@@ -31,7 +33,10 @@ references:
         - APPL-14-004040
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/os/os_nfsd_disable.yaml
+++ b/src/mscp/data/rules/os/os_nfsd_disable.yaml
@@ -25,6 +25,8 @@ references:
     srg:
       - SRG-OS-000080-GPOS-00048
     disa_stig:
+      macos_27:
+        - APPL-27-002003
       macos_26:
         - APPL-26-002003
       macos_15:
@@ -54,7 +56,10 @@ references:
       - 4.8
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/os/os_on_device_dictation_enforce.yaml
+++ b/src/mscp/data/rules/os/os_on_device_dictation_enforce.yaml
@@ -41,6 +41,8 @@ references:
     srg:
       - SRG-OS-000095-GPOS-00049
     disa_stig:
+      macos_27:
+        - APPL-27-002220
       macos_26:
         - APPL-26-002220
       macos_15:
@@ -88,7 +90,10 @@ references:
         - ANNEX K
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/os/os_password_hint_remove.yaml
+++ b/src/mscp/data/rules/os/os_password_hint_remove.yaml
@@ -23,6 +23,8 @@ references:
     srg:
       - SRG-OS-000079-GPOS-00047
     disa_stig:
+      macos_27:
+        - APPL-27-003014
       macos_26:
         - APPL-26-003014
       macos_15:
@@ -47,7 +49,10 @@ references:
       - 5.2
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/os/os_password_proximity_disable.yaml
+++ b/src/mscp/data/rules/os/os_password_proximity_disable.yaml
@@ -33,6 +33,8 @@ references:
     srg:
       - SRG-OS-000095-GPOS-00049
     disa_stig:
+      macos_27:
+        - APPL-27-005060
       macos_26:
         - APPL-26-005060
       macos_15:
@@ -79,7 +81,10 @@ references:
         - ANNEX K
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/os/os_policy_banner_loginwindow_enforce.yaml
+++ b/src/mscp/data/rules/os/os_policy_banner_loginwindow_enforce.yaml
@@ -42,6 +42,8 @@ references:
       - SRG-OS-000228-GPOS-00088
       - SRG-OS-000023-GPOS-00006
     disa_stig:
+      macos_27:
+        - APPL-27-000025
       macos_26:
         - APPL-26-000025
       macos_15:
@@ -62,7 +64,10 @@ references:
       - 4.1
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl2

--- a/src/mscp/data/rules/os/os_policy_banner_ssh_configure.yaml
+++ b/src/mscp/data/rules/os/os_policy_banner_ssh_configure.yaml
@@ -29,6 +29,8 @@ references:
       - SRG-OS-000024-GPOS-00007
       - SRG-OS-000023-GPOS-00006
     disa_stig:
+      macos_27:
+        - APPL-27-000023
       macos_26:
         - APPL-26-000023
       macos_15:
@@ -39,7 +41,10 @@ references:
       - AC.L2-3.1.9
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/os/os_policy_banner_ssh_enforce.yaml
+++ b/src/mscp/data/rules/os/os_policy_banner_ssh_enforce.yaml
@@ -31,6 +31,8 @@ references:
       - SRG-OS-000024-GPOS-00007
       - SRG-OS-000023-GPOS-00006
     disa_stig:
+      macos_27:
+        - APPL-27-000024
       macos_26:
         - APPL-26-000024
       macos_15:
@@ -41,7 +43,10 @@ references:
       - AC.L2-3.1.9
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/os/os_privacy_setup_prompt_disable.yaml
+++ b/src/mscp/data/rules/os/os_privacy_setup_prompt_disable.yaml
@@ -26,6 +26,8 @@ references:
     srg:
       - SRG-OS-000095-GPOS-00049
     disa_stig:
+      macos_27:
+        - APPL-27-002036
       macos_26:
         - APPL-26-002036
       macos_15:
@@ -44,7 +46,10 @@ references:
       - 4.8
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/os/os_recovery_lock_enable.yaml
+++ b/src/mscp/data/rules/os/os_recovery_lock_enable.yaml
@@ -27,6 +27,8 @@ references:
     srg:
       - SRG-OS-000480-GPOS-00227
     disa_stig:
+      macos_27:
+        - APPL-27-005120
       macos_26:
         - APPL-26-005120
       macos_15:
@@ -42,7 +44,10 @@ references:
       - 3.L.C
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/os/os_root_disable.yaml
+++ b/src/mscp/data/rules/os/os_root_disable.yaml
@@ -31,6 +31,8 @@ references:
       - SRG-OS-000109-GPOS-00056
       - SRG-OS-000104-GPOS-00051
     disa_stig:
+      macos_27:
+        - APPL-27-000100
       macos_26:
         - APPL-26-000100
       macos_15:
@@ -56,7 +58,10 @@ references:
       - 5.4
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/os/os_secure_boot_verify.yaml
+++ b/src/mscp/data/rules/os/os_secure_boot_verify.yaml
@@ -32,6 +32,8 @@ references:
       - SRG-OS-000445-GPOS-00199
       - SRG-OS-000446-GPOS-00200
     disa_stig:
+      macos_27:
+        - APPL-27-005100
       macos_26:
         - APPL-26-005100
       macos_15:
@@ -47,7 +49,10 @@ references:
       - 2.L.C
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/os/os_sip_enable.yaml
+++ b/src/mscp/data/rules/os/os_sip_enable.yaml
@@ -66,6 +66,8 @@ references:
       - SRG-OS-000122-GPOS-00063
       - SRG-OS-000058-GPOS-00028
     disa_stig:
+      macos_27:
+        - APPL-27-005001
       macos_26:
         - APPL-26-005001
       macos_15:
@@ -99,7 +101,10 @@ references:
       - 10.5
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: high
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/os/os_siri_prompt_disable.yaml
+++ b/src/mscp/data/rules/os/os_siri_prompt_disable.yaml
@@ -29,6 +29,8 @@ references:
     srg:
       - SRG-OS-000095-GPOS-00049
     disa_stig:
+      macos_27:
+        - APPL-27-002039
       macos_26:
         - APPL-26-002039
       macos_15:
@@ -48,7 +50,10 @@ references:
       - 4.8
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/os/os_skip_apple_intelligence_enable.yaml
+++ b/src/mscp/data/rules/os/os_skip_apple_intelligence_enable.yaml
@@ -22,6 +22,8 @@ references:
     srg:
       - SRG-OS-000095-GPOS-000049
     disa_stig:
+      macos_27:
+        - APPL-27-005170
       macos_26:
         - APPL-26-005170
     cmmc:
@@ -36,7 +38,10 @@ references:
       - 4.1
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/os/os_skip_screen_time_prompt_enable.yaml
+++ b/src/mscp/data/rules/os/os_skip_screen_time_prompt_enable.yaml
@@ -23,6 +23,8 @@ references:
     srg:
       - SRG-OS-000095-GPOS-00049
     disa_stig:
+      macos_27:
+        - APPL-27-005055
       macos_26:
         - APPL-26-005055
       macos_15:
@@ -37,7 +39,10 @@ references:
       - 2.L.A
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: low
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/os/os_skip_unlock_with_watch_enable.yaml
+++ b/src/mscp/data/rules/os/os_skip_unlock_with_watch_enable.yaml
@@ -26,6 +26,8 @@ references:
     srg:
       - SRG-OS-000095-GPOS-00049
     disa_stig:
+      macos_27:
+        - APPL-27-005056
       macos_26:
         - APPL-26-005056
       macos_15:
@@ -39,7 +41,10 @@ references:
       - 4.1
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/os/os_ssh_fips_compliant.yaml
+++ b/src/mscp/data/rules/os/os_ssh_fips_compliant.yaml
@@ -44,6 +44,8 @@ references:
       - SRG-OS-000033-GPOS-00014
       - SRG-OS-000396-GPOS-00176
     disa_stig:
+      macos_27:
+        - APPL-27-000057
       macos_26:
         - APPL-26-000057
       macos_15:
@@ -60,7 +62,10 @@ references:
       - 6.L.C
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: high
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/os/os_ssh_server_alive_count_max_configure.yaml
+++ b/src/mscp/data/rules/os/os_ssh_server_alive_count_max_configure.yaml
@@ -27,6 +27,8 @@ references:
     srg:
       - SRG-OS-000163-GPOS-00072
     disa_stig:
+      macos_27:
+        - APPL-27-000140
       macos_26:
         - APPL-26-000140
       macos_15:
@@ -37,7 +39,10 @@ references:
       - SC.L2-3.13.9
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/os/os_ssh_server_alive_interval_configure.yaml
+++ b/src/mscp/data/rules/os/os_ssh_server_alive_interval_configure.yaml
@@ -31,6 +31,8 @@ references:
     srg:
       - SRG-OS-000163-GPOS-00072
     disa_stig:
+      macos_27:
+        - APPL-27-000110
       macos_26:
         - APPL-26-000110
       macos_15:
@@ -42,7 +44,10 @@ references:
       - SC.L2-3.13.9
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/os/os_sshd_channel_timeout_configure.yaml
+++ b/src/mscp/data/rules/os/os_sshd_channel_timeout_configure.yaml
@@ -33,6 +33,8 @@ references:
       - SRG-OS-000163-GPOS-00072
       - SRG-OS-000279-GPOS-00109
     disa_stig:
+      macos_27:
+        - APPL-27-000120
       macos_26:
         - APPL-26-000120
       macos_15:
@@ -44,7 +46,10 @@ references:
       - SC.L2-3.13.9
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/os/os_sshd_client_alive_count_max_configure.yaml
+++ b/src/mscp/data/rules/os/os_sshd_client_alive_count_max_configure.yaml
@@ -31,6 +31,8 @@ references:
     srg:
       - SRG-OS-000163-GPOS-00072
     disa_stig:
+      macos_27:
+        - APPL-27-000052
       macos_26:
         - APPL-26-000052
       macos_15:
@@ -41,7 +43,10 @@ references:
       - SC.L2-3.13.9
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/os/os_sshd_client_alive_interval_configure.yaml
+++ b/src/mscp/data/rules/os/os_sshd_client_alive_interval_configure.yaml
@@ -33,6 +33,8 @@ references:
     srg:
       - SRG-OS-000163-GPOS-00072
     disa_stig:
+      macos_27:
+        - APPL-27-000051
       macos_26:
         - APPL-26-000051
       macos_15:
@@ -44,7 +46,10 @@ references:
       - SC.L2-3.13.9
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/os/os_sshd_fips_compliant.yaml
+++ b/src/mscp/data/rules/os/os_sshd_fips_compliant.yaml
@@ -48,6 +48,8 @@ references:
       - SRG-OS-000393-GPOS-00173
       - SRG-OS-000396-GPOS-00176
     disa_stig:
+      macos_27:
+        - APPL-27-000054
       macos_26:
         - APPL-26-000054
       macos_15:
@@ -64,7 +66,10 @@ references:
       - 6.L.C
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: high
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/os/os_sshd_login_grace_time_configure.yaml
+++ b/src/mscp/data/rules/os/os_sshd_login_grace_time_configure.yaml
@@ -25,6 +25,8 @@ references:
     srg:
       - SRG-OS-000163-GPOS-00072
     disa_stig:
+      macos_27:
+        - APPL-27-000053
       macos_26:
         - APPL-26-000053
       macos_15:
@@ -35,7 +37,10 @@ references:
       - SC.L2-3.13.9
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/os/os_sshd_permit_root_login_configure.yaml
+++ b/src/mscp/data/rules/os/os_sshd_permit_root_login_configure.yaml
@@ -28,6 +28,8 @@ references:
       - SRG-OS-000364-GPOS-00151
       - SRG-OS-000109-GPOS-00056
     disa_stig:
+      macos_27:
+        - APPL-27-001100
       macos_26:
         - APPL-26-001100
       macos_15:
@@ -36,7 +38,10 @@ references:
         - APPL-14-001100
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/os/os_sshd_unused_connection_timeout_configure.yaml
+++ b/src/mscp/data/rules/os/os_sshd_unused_connection_timeout_configure.yaml
@@ -31,6 +31,8 @@ references:
       - SRG-OS-000163-GPOS-00072
       - SRG-OS-000279-GPOS-00109
     disa_stig:
+      macos_27:
+        - APPL-27-000130
       macos_26:
         - APPL-26-000130
       macos_15:
@@ -42,7 +44,10 @@ references:
       - SC.L2-3.13.9
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/os/os_sudo_log_enforce.yaml
+++ b/src/mscp/data/rules/os/os_sudo_log_enforce.yaml
@@ -21,6 +21,8 @@ references:
     srg:
       - SRG-OS-000064-GPOS-00033
     disa_stig:
+      macos_27:
+        - APPL-27-000190
       macos_26:
         - APPL-26-000190
       macos_15:
@@ -41,7 +43,10 @@ references:
         - 5.11 (level 1)
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/os/os_sudo_timeout_configure.yaml
+++ b/src/mscp/data/rules/os/os_sudo_timeout_configure.yaml
@@ -19,6 +19,8 @@ references:
     srg:
       - SRG-OS-000373-GPOS-00156
     disa_stig:
+      macos_27:
+        - APPL-27-004022
       macos_26:
         - APPL-26-004022
       macos_15:
@@ -41,7 +43,10 @@ references:
       - 4.3
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/os/os_sudoers_timestamp_type_configure.yaml
+++ b/src/mscp/data/rules/os/os_sudoers_timestamp_type_configure.yaml
@@ -27,6 +27,8 @@ references:
       - SRG-OS-000373-GPOS-00157
       - SRG-OS-000373-GPOS-00156
     disa_stig:
+      macos_27:
+        - APPL-27-004060
       macos_26:
         - APPL-26-004060
       macos_15:
@@ -49,7 +51,10 @@ references:
       - 4.3
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/os/os_supported_operating_system.yaml
+++ b/src/mscp/data/rules/os/os_supported_operating_system.yaml
@@ -21,11 +21,15 @@ references:
     srg:
       - SRG-OS-000830-GPOS-00300
     disa_stig:
+      macos_27:
+        - APPL-27-006000
       macos_26:
         - APPL-26-006000
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/os/os_tftpd_disable.yaml
+++ b/src/mscp/data/rules/os/os_tftpd_disable.yaml
@@ -33,6 +33,8 @@ references:
       - SRG-OS-000080-GPOS-00048
       - SRG-OS-000074-GPOS-00042
     disa_stig:
+      macos_27:
+        - APPL-27-002038
       macos_26:
         - APPL-26-002038
       macos_15:
@@ -61,7 +63,10 @@ references:
       - 5.2
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: high
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/os/os_time_server_enabled.yaml
+++ b/src/mscp/data/rules/os/os_time_server_enabled.yaml
@@ -32,6 +32,8 @@ references:
       - SRG-OS-000356-GPOS-00144
       - SRG-OS-000785-GPOS-00250
     disa_stig:
+      macos_27:
+        - APPL-27-000180
       macos_26:
         - APPL-26-000180
       macos_15:
@@ -55,7 +57,10 @@ references:
       - 8.4
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/os/os_touchid_prompt_disable.yaml
+++ b/src/mscp/data/rules/os/os_touchid_prompt_disable.yaml
@@ -25,6 +25,8 @@ references:
     srg:
       - SRG-OS-000095-GPOS-00049
     disa_stig:
+      macos_27:
+        - APPL-27-005054
       macos_26:
         - APPL-26-005054
       macos_15:
@@ -42,7 +44,10 @@ references:
       - 4.1
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/os/os_unlock_active_user_session_disable.yaml
+++ b/src/mscp/data/rules/os/os_unlock_active_user_session_disable.yaml
@@ -33,6 +33,8 @@ references:
       - SRG-OS-000109-GPOS-00056
       - SRG-OS-000104-GPOS-00051
     disa_stig:
+      macos_27:
+        - APPL-27-000090
       macos_26:
         - APPL-26-000090
       macos_15:
@@ -58,7 +60,10 @@ references:
       - 4.3
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/os/os_user_app_installation_prohibit.yaml
+++ b/src/mscp/data/rules/os/os_user_app_installation_prohibit.yaml
@@ -31,6 +31,8 @@ references:
     srg:
       - SRG-OS-000362-GPOS-00149
     disa_stig:
+      macos_27:
+        - APPL-27-005080
       macos_26:
         - APPL-26-005080
       macos_15:
@@ -45,7 +47,10 @@ references:
       - 2.L.B
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/os/os_uucp_disable.yaml
+++ b/src/mscp/data/rules/os/os_uucp_disable.yaml
@@ -29,6 +29,8 @@ references:
     srg:
       - SRG-OS-000080-GPOS-00048
     disa_stig:
+      macos_27:
+        - APPL-27-002006
       macos_26:
         - APPL-26-002006
       macos_15:
@@ -47,7 +49,10 @@ references:
       - 4.8
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/os/os_writing_tools_disable.yaml
+++ b/src/mscp/data/rules/os/os_writing_tools_disable.yaml
@@ -37,6 +37,8 @@ references:
     srg:
       - SRG-OS-000095-GPOS-00049
     disa_stig:
+      macos_27:
+        - APPL-27-005160
       macos_26:
         - APPL-26-005160
       macos_15:
@@ -67,7 +69,10 @@ references:
         - ANNEX K
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/pwpolicy/pwpolicy_account_inactivity_enforce.yaml
+++ b/src/mscp/data/rules/pwpolicy/pwpolicy_account_inactivity_enforce.yaml
@@ -28,6 +28,8 @@ references:
       - SRG-OS-000118-GPOS-00060
       - SRG-OS-000590-GPOS-00110
     disa_stig:
+      macos_27:
+        - APPL-27-003080
       macos_26:
         - APPL-26-003080
       macos_15:
@@ -41,7 +43,10 @@ references:
       - 5.3
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/pwpolicy/pwpolicy_account_lockout_enforce.yaml
+++ b/src/mscp/data/rules/pwpolicy/pwpolicy_account_lockout_enforce.yaml
@@ -39,6 +39,8 @@ references:
       - SRG-OS-000329-GPOS-00128
       - SRG-OS-000021-GPOS-00005
     disa_stig:
+      macos_27:
+        - APPL-27-000022
       macos_26:
         - APPL-26-000022
       macos_15:
@@ -88,7 +90,10 @@ references:
         - ANNEX K
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/pwpolicy/pwpolicy_account_lockout_timeout_enforce.yaml
+++ b/src/mscp/data/rules/pwpolicy/pwpolicy_account_lockout_timeout_enforce.yaml
@@ -27,6 +27,8 @@ references:
       - SRG-OS-000329-GPOS-00128
       - SRG-OS-000021-GPOS-00005
     disa_stig:
+      macos_27:
+        - APPL-27-000060
       macos_26:
         - APPL-26-000060
       macos_15:
@@ -47,7 +49,10 @@ references:
       - 6.2
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/pwpolicy/pwpolicy_alpha_numeric_enforce.yaml
+++ b/src/mscp/data/rules/pwpolicy/pwpolicy_alpha_numeric_enforce.yaml
@@ -37,6 +37,8 @@ references:
       - SRG-OS-000071-GPOS-00039
       - SRG-OS-000775-GPOS-00230
     disa_stig:
+      macos_27:
+        - APPL-27-003007
       macos_26:
         - APPL-26-003007
       macos_15:
@@ -77,7 +79,10 @@ references:
         - ANNEX K
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl2

--- a/src/mscp/data/rules/pwpolicy/pwpolicy_custom_regex_enforce.yaml
+++ b/src/mscp/data/rules/pwpolicy/pwpolicy_custom_regex_enforce.yaml
@@ -35,6 +35,8 @@ references:
       - SRG-OS-000070-GPOS-00038
       - SRG-OS-000069-GPOS-00037
     disa_stig:
+      macos_27:
+        - APPL-27-003060
       macos_26:
         - APPL-26-003060
       macos_15:
@@ -61,7 +63,10 @@ references:
       - 5.2
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl2

--- a/src/mscp/data/rules/pwpolicy/pwpolicy_max_lifetime_enforce.yaml
+++ b/src/mscp/data/rules/pwpolicy/pwpolicy_max_lifetime_enforce.yaml
@@ -29,6 +29,8 @@ references:
       - SRG-OS-000076-GPOS-00044
       - SRG-OS-000775-GPOS-00230
     disa_stig:
+      macos_27:
+        - APPL-27-003008
       macos_26:
         - APPL-26-003008
       macos_15:
@@ -54,7 +56,10 @@ references:
       - 5.3
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1
@@ -82,7 +87,7 @@ odv:
   recommended: 60
   cis_lvl1: 365
   cis_lvl2: 365
-  disa_stig: 60
+  disa_stig: 180
 tags:
   - cisv8
   - cnssi-1253_low

--- a/src/mscp/data/rules/pwpolicy/pwpolicy_minimum_length_enforce.yaml
+++ b/src/mscp/data/rules/pwpolicy/pwpolicy_minimum_length_enforce.yaml
@@ -40,6 +40,8 @@ references:
     srg:
       - SRG-OS-000078-GPOS-00046
     disa_stig:
+      macos_27:
+        - APPL-27-003010
       macos_26:
         - APPL-26-003010
       macos_15:
@@ -99,7 +101,10 @@ references:
         - ANNEX K
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/pwpolicy/pwpolicy_minimum_lifetime_enforce.yaml
+++ b/src/mscp/data/rules/pwpolicy/pwpolicy_minimum_lifetime_enforce.yaml
@@ -28,6 +28,8 @@ references:
     srg:
       - SRG-OS-000075-GPOS-00043
     disa_stig:
+      macos_27:
+        - APPL-27-003070
       macos_26:
         - APPL-26-003070
       macos_15:
@@ -46,7 +48,10 @@ references:
       - 4.7
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/pwpolicy/pwpolicy_special_character_enforce.yaml
+++ b/src/mscp/data/rules/pwpolicy/pwpolicy_special_character_enforce.yaml
@@ -30,6 +30,8 @@ references:
     srg:
       - SRG-OS-000266-GPOS-00101
     disa_stig:
+      macos_27:
+        - APPL-27-003011
       macos_26:
         - APPL-26-003011
       macos_15:
@@ -56,7 +58,10 @@ references:
       - 5.2
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl2

--- a/src/mscp/data/rules/pwpolicy/pwpolicy_temporary_or_emergency_accounts_disable.yaml
+++ b/src/mscp/data/rules/pwpolicy/pwpolicy_temporary_or_emergency_accounts_disable.yaml
@@ -37,6 +37,8 @@ references:
       - SRG-OS-000002-GPOS-00002
       - SRG-OS-000123-GPOS-00064
     disa_stig:
+      macos_27:
+        - APPL-27-000012
       macos_26:
         - APPL-26-000012
       macos_15:
@@ -45,7 +47,10 @@ references:
         - APPL-14-000012
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/system_settings/system_settings_airplay_receiver_disable.yaml
+++ b/src/mscp/data/rules/system_settings/system_settings_airplay_receiver_disable.yaml
@@ -30,6 +30,8 @@ references:
       - SRG-OS-000300-GPOS-00118
       - SRG-OS-000095-GPOS-00049
     disa_stig:
+      macos_27:
+        - APPL-27-002080
       macos_26:
         - APPL-26-002080
       macos_15:
@@ -57,7 +59,10 @@ references:
       - 4.8
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/system_settings/system_settings_apple_watch_unlock_disable.yaml
+++ b/src/mscp/data/rules/system_settings/system_settings_apple_watch_unlock_disable.yaml
@@ -27,6 +27,8 @@ references:
     srg:
       - SRG-OS-000028-GPOS-00009
     disa_stig:
+      macos_27:
+        - APPL-27-000001
       macos_26:
         - APPL-26-000001
       macos_15:
@@ -41,7 +43,10 @@ references:
       - 3.L.A
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/system_settings/system_settings_automatic_login_disable.yaml
+++ b/src/mscp/data/rules/system_settings/system_settings_automatic_login_disable.yaml
@@ -28,6 +28,8 @@ references:
       - SRG-OS-000104-GPOS-00051
       - SRG-OS-000480-GPOS-00228
     disa_stig:
+      macos_27:
+        - APPL-27-002066
       macos_26:
         - APPL-26-002066
       macos_15:
@@ -53,7 +55,10 @@ references:
       - 4.7
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/system_settings/system_settings_automatic_logout_enforce.yaml
+++ b/src/mscp/data/rules/system_settings/system_settings_automatic_logout_enforce.yaml
@@ -32,6 +32,8 @@ references:
     srg:
       - SRG-OS-000279-GPOS-00109
     disa_stig:
+      macos_27:
+        - APPL-27-000160
       macos_26:
         - APPL-26-000160
       macos_15:
@@ -43,7 +45,10 @@ references:
       - AC.L2-3.1.11
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/system_settings/system_settings_biometric_disable.yaml
+++ b/src/mscp/data/rules/system_settings/system_settings_biometric_disable.yaml
@@ -33,6 +33,8 @@ references:
     srg:
       - SRG-OS-000028-GPOS-00009
     disa_stig:
+      macos_27:
+        - APPL-27-002090
       macos_26:
         - APPL-26-002090
       macos_15:
@@ -48,7 +50,10 @@ references:
       - 2.L.B
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/system_settings/system_settings_bluetooth_disable.yaml
+++ b/src/mscp/data/rules/system_settings/system_settings_bluetooth_disable.yaml
@@ -34,6 +34,8 @@ references:
       - SRG-OS-000481-GPOS-00481
       - SRG-OS-000480-GPOS-00228
     disa_stig:
+      macos_27:
+        - APPL-27-002062
       macos_26:
         - APPL-26-002062
       macos_15:
@@ -52,7 +54,10 @@ references:
       - 13.9
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: high
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/system_settings/system_settings_bluetooth_settings_disable.yaml
+++ b/src/mscp/data/rules/system_settings/system_settings_bluetooth_settings_disable.yaml
@@ -24,6 +24,8 @@ references:
     srg:
       - SRG-OS-000095-GPOS-00049
     disa_stig:
+      macos_27:
+        - APPL-27-002260
       macos_26:
         - APPL-26-002260
       macos_15:
@@ -44,7 +46,10 @@ references:
       - 4.8
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/system_settings/system_settings_bluetooth_sharing_disable.yaml
+++ b/src/mscp/data/rules/system_settings/system_settings_bluetooth_sharing_disable.yaml
@@ -37,6 +37,8 @@ references:
       - SRG-OS-000080-GPOS-00048
       - SRG-OS-000095-GPOS-00049
     disa_stig:
+      macos_27:
+        - APPL-27-002110
       macos_26:
         - APPL-26-002110
       macos_15:
@@ -64,7 +66,10 @@ references:
       - 4.1
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/system_settings/system_settings_content_caching_disable.yaml
+++ b/src/mscp/data/rules/system_settings/system_settings_content_caching_disable.yaml
@@ -26,6 +26,8 @@ references:
     srg:
       - SRG-OS-000095-GPOS-00049
     disa_stig:
+      macos_27:
+        - APPL-27-002140
       macos_26:
         - APPL-26-002140
       macos_15:
@@ -50,7 +52,10 @@ references:
       - 4.8
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl2

--- a/src/mscp/data/rules/system_settings/system_settings_diagnostics_reports_disable.yaml
+++ b/src/mscp/data/rules/system_settings/system_settings_diagnostics_reports_disable.yaml
@@ -29,6 +29,8 @@ references:
       - SRG-OS-000206-GPOS-00084
       - SRG-OS-000205-GPOS-00083
     disa_stig:
+      macos_27:
+        - APPL-27-002021
       macos_26:
         - APPL-26-002021
       macos_15:
@@ -59,7 +61,10 @@ references:
       - 4.8
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/system_settings/system_settings_external_intelligence_disable.yaml
+++ b/src/mscp/data/rules/system_settings/system_settings_external_intelligence_disable.yaml
@@ -37,6 +37,8 @@ references:
       - CCI-000381
       - CCI-000366
     disa_stig:
+      macos_27:
+        - APPL-27-005190
       ios_26:
         - AIOS-26-015400
       ios_18:
@@ -76,7 +78,10 @@ references:
         - ANNEX K      
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/system_settings/system_settings_external_intelligence_sign_in_disable.yaml
+++ b/src/mscp/data/rules/system_settings/system_settings_external_intelligence_sign_in_disable.yaml
@@ -38,6 +38,8 @@ references:
     srg:
       - SRG-OS-000095-GPOS-00049
     disa_stig:
+      macos_27:
+        - APPL-27-005200
       ios_26:
         - AIOS-26-015400
       ios_18:
@@ -81,7 +83,10 @@ references:
       - 15.3
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/system_settings/system_settings_filevault_enforce.yaml
+++ b/src/mscp/data/rules/system_settings/system_settings_filevault_enforce.yaml
@@ -34,6 +34,8 @@ references:
       - SRG-OS-000405-GPOS-00184
       - SRG-OS-000404-GPOS-00183
     disa_stig:
+      macos_27:
+        - APPL-27-005020
       macos_26:
         - APPL-26-005020
       macos_15:
@@ -66,7 +68,10 @@ references:
       - 3.11
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: high
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/system_settings/system_settings_find_my_disable.yaml
+++ b/src/mscp/data/rules/system_settings/system_settings_find_my_disable.yaml
@@ -30,6 +30,8 @@ references:
     srg:
       - SRG-OS-000095-GPOS-00049
     disa_stig:
+      macos_27:
+        - APPL-27-002180
       macos_26:
         - APPL-26-002180
       macos_15:
@@ -57,7 +59,10 @@ references:
       - 15.3
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/system_settings/system_settings_firewall_enable.yaml
+++ b/src/mscp/data/rules/system_settings/system_settings_firewall_enable.yaml
@@ -31,6 +31,8 @@ references:
     srg:
       - SRG-OS-000480-GPOS-00232
     disa_stig:
+      macos_27:
+        - APPL-27-005050
       macos_26:
         - APPL-26-005050
       macos_15:
@@ -64,7 +66,10 @@ references:
       - 13.1
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/system_settings/system_settings_gatekeeper_identified_developers_allowed.yaml
+++ b/src/mscp/data/rules/system_settings/system_settings_gatekeeper_identified_developers_allowed.yaml
@@ -30,6 +30,8 @@ references:
       - SRG-OS-000366-GPOS-00153
       - SRG-OS-000480-GPOS-00228
     disa_stig:
+      macos_27:
+        - APPL-27-002060
       macos_26:
         - APPL-26-002060
       macos_15:
@@ -44,7 +46,10 @@ references:
       - 8.19.01
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: high
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/system_settings/system_settings_guest_account_disable.yaml
+++ b/src/mscp/data/rules/system_settings/system_settings_guest_account_disable.yaml
@@ -27,6 +27,8 @@ references:
       - SRG-OS-000364-GPOS-00151
       - SRG-OS-000480-GPOS-00228
     disa_stig:
+      macos_27:
+        - APPL-27-002063
       macos_26:
         - APPL-26-002063
       macos_15:
@@ -58,7 +60,10 @@ references:
       - 6.8
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/system_settings/system_settings_hot_corners_disable.yaml
+++ b/src/mscp/data/rules/system_settings/system_settings_hot_corners_disable.yaml
@@ -25,6 +25,8 @@ references:
     srg:
       - SRG-OS-000031-GPOS-00012
     disa_stig:
+      macos_27:
+        - APPL-27-000007
       macos_26:
         - APPL-26-000007
       macos_15:
@@ -35,7 +37,10 @@ references:
       - AC.L2-3.1.10
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/system_settings/system_settings_improve_assistive_voice_disable.yaml
+++ b/src/mscp/data/rules/system_settings/system_settings_improve_assistive_voice_disable.yaml
@@ -27,6 +27,8 @@ references:
     srg:
       - SRG-OS-000095-GPOS-00049
     disa_stig:
+      macos_27:
+        - APPL-27-002023
       macos_26:
         - APPL-26-002023
       macos_15:
@@ -54,7 +56,10 @@ references:
       - 4.8
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/system_settings/system_settings_improve_search_disable.yaml
+++ b/src/mscp/data/rules/system_settings/system_settings_improve_search_disable.yaml
@@ -27,6 +27,8 @@ references:
     srg:
       - SRG-OS-000095-GPOS-00049
     disa_stig:
+      macos_27:
+        - APPL-27-002024
       macos_26:
         - APPL-26-002024
       macos_15:
@@ -53,7 +55,10 @@ references:
       - 4.8
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/system_settings/system_settings_improve_siri_dictation_disable.yaml
+++ b/src/mscp/data/rules/system_settings/system_settings_improve_siri_dictation_disable.yaml
@@ -29,6 +29,8 @@ references:
     srg:
       - SRG-OS-000095-GPOS-00049
     disa_stig:
+      macos_27:
+        - APPL-27-002210
       macos_26:
         - APPL-26-002210
       macos_15:
@@ -60,7 +62,10 @@ references:
       - 4.8
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/system_settings/system_settings_internet_sharing_disable.yaml
+++ b/src/mscp/data/rules/system_settings/system_settings_internet_sharing_disable.yaml
@@ -27,6 +27,8 @@ references:
     srg:
       - SRG-OS-000095-GPOS-00049
     disa_stig:
+      macos_27:
+        - APPL-27-002007
       macos_26:
         - APPL-26-002007
       macos_15:
@@ -57,7 +59,10 @@ references:
       - 4.8
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/system_settings/system_settings_location_services_disable.yaml
+++ b/src/mscp/data/rules/system_settings/system_settings_location_services_disable.yaml
@@ -27,6 +27,8 @@ references:
     srg:
       - SRG-OS-000095-GPOS-00049
     disa_stig:
+      macos_27:
+        - APPL-27-002004
       macos_26:
         - APPL-26-002004
       macos_15:
@@ -42,7 +44,10 @@ references:
       - 4.L.A
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/system_settings/system_settings_loginwindow_prompt_username_password_enforce.yaml
+++ b/src/mscp/data/rules/system_settings/system_settings_loginwindow_prompt_username_password_enforce.yaml
@@ -25,6 +25,8 @@ references:
     srg:
       - SRG-OS-000104-GPOS-00051
     disa_stig:
+      macos_27:
+        - APPL-27-005052
       macos_26:
         - APPL-26-005052
       macos_15:
@@ -46,7 +48,10 @@ references:
       - 4.1
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/system_settings/system_settings_media_sharing_disabled.yaml
+++ b/src/mscp/data/rules/system_settings/system_settings_media_sharing_disabled.yaml
@@ -31,6 +31,8 @@ references:
     srg:
       - SRG-OS-000080-GPOS-00048
     disa_stig:
+      macos_27:
+        - APPL-27-002100
       macos_26:
         - APPL-26-002100
       macos_15:
@@ -61,7 +63,10 @@ references:
       - 4.8
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl2

--- a/src/mscp/data/rules/system_settings/system_settings_password_hints_disable.yaml
+++ b/src/mscp/data/rules/system_settings/system_settings_password_hints_disable.yaml
@@ -25,6 +25,8 @@ references:
     srg:
       - SRG-OS-000079-GPOS-00047
     disa_stig:
+      macos_27:
+        - APPL-27-003012
       macos_26:
         - APPL-26-003012
       macos_15:
@@ -49,7 +51,10 @@ references:
       - 4.1
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/system_settings/system_settings_personalized_advertising_disable.yaml
+++ b/src/mscp/data/rules/system_settings/system_settings_personalized_advertising_disable.yaml
@@ -29,6 +29,8 @@ references:
     srg:
       - SRG-OS-000095-GPOS-00049
     disa_stig:
+      macos_27:
+        - APPL-27-002200
       macos_26:
         - APPL-26-002200
       macos_15:
@@ -58,7 +60,10 @@ references:
       - 4.8
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/system_settings/system_settings_printer_sharing_disable.yaml
+++ b/src/mscp/data/rules/system_settings/system_settings_printer_sharing_disable.yaml
@@ -24,6 +24,8 @@ references:
     srg:
       - SRG-OS-000095-GPOS-00049
     disa_stig:
+      macos_27:
+        - APPL-27-002240
       macos_26:
         - APPL-26-002240
       macos_15:
@@ -55,7 +57,10 @@ references:
       - 4.8
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/system_settings/system_settings_rae_disable.yaml
+++ b/src/mscp/data/rules/system_settings/system_settings_rae_disable.yaml
@@ -29,6 +29,8 @@ references:
       - SRG-OS-000080-GPOS-00048
       - SRG-OS-000096-GPOS-00050
     disa_stig:
+      macos_27:
+        - APPL-27-002022
       macos_26:
         - APPL-26-002022
       macos_15:
@@ -59,7 +61,10 @@ references:
       - 4.8
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/system_settings/system_settings_remote_management_disable.yaml
+++ b/src/mscp/data/rules/system_settings/system_settings_remote_management_disable.yaml
@@ -25,6 +25,8 @@ references:
     srg:
       - SRG-OS-000095-GPOS-00049
     disa_stig:
+      macos_27:
+        - APPL-27-002250
       macos_26:
         - APPL-26-002250
       macos_15:
@@ -56,7 +58,10 @@ references:
       - 5.4
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/system_settings/system_settings_screen_sharing_disable.yaml
+++ b/src/mscp/data/rules/system_settings/system_settings_screen_sharing_disable.yaml
@@ -27,6 +27,8 @@ references:
     srg:
       - SRG-OS-000080-GPOS-00048
     disa_stig:
+      macos_27:
+        - APPL-27-002050
       macos_26:
         - APPL-26-002050
       macos_15:
@@ -57,7 +59,10 @@ references:
       - 4.8
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/system_settings/system_settings_screensaver_ask_for_password_delay_enforce.yaml
+++ b/src/mscp/data/rules/system_settings/system_settings_screensaver_ask_for_password_delay_enforce.yaml
@@ -25,6 +25,8 @@ references:
     srg:
       - SRG-OS-000028-GPOS-00009
     disa_stig:
+      macos_27:
+        - APPL-27-000003
       macos_26:
         - APPL-26-000003
       macos_15:
@@ -49,7 +51,10 @@ references:
       - 4.7
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/system_settings/system_settings_screensaver_password_enforce.yaml
+++ b/src/mscp/data/rules/system_settings/system_settings_screensaver_password_enforce.yaml
@@ -26,6 +26,8 @@ references:
     srg:
       - SRG-OS-000028-GPOS-00009
     disa_stig:
+      macos_27:
+        - APPL-27-000002
       macos_26:
         - APPL-26-000002
       macos_15:
@@ -46,7 +48,10 @@ references:
       - 4.7
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/system_settings/system_settings_screensaver_timeout_enforce.yaml
+++ b/src/mscp/data/rules/system_settings/system_settings_screensaver_timeout_enforce.yaml
@@ -27,6 +27,8 @@ references:
     srg:
       - SRG-OS-000029-GPOS-00010
     disa_stig:
+      macos_27:
+        - APPL-27-000070
       macos_26:
         - APPL-26-000070
       macos_15:
@@ -51,7 +53,10 @@ references:
       - 4.3
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/system_settings/system_settings_siri_disable.yaml
+++ b/src/mscp/data/rules/system_settings/system_settings_siri_disable.yaml
@@ -45,6 +45,8 @@ references:
     srg:
       - SRG-OS-000095-GPOS-00049
     disa_stig:
+      macos_27:
+        - APPL-27-002020
       macos_26:
         - APPL-26-002020
       macos_15:
@@ -87,7 +89,10 @@ references:
       - 4.8
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/system_settings/system_settings_siri_settings_disable.yaml
+++ b/src/mscp/data/rules/system_settings/system_settings_siri_settings_disable.yaml
@@ -30,6 +30,8 @@ references:
     srg:
       - SRG-OS-000095-GPOS-00049
     disa_stig:
+      macos_27:
+        - APPL-27-002053
       macos_26:
         - APPL-26-002053
       macos_15:
@@ -49,7 +51,10 @@ references:
       - 4.8
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/system_settings/system_settings_smbd_disable.yaml
+++ b/src/mscp/data/rules/system_settings/system_settings_smbd_disable.yaml
@@ -27,6 +27,8 @@ references:
     srg:
       - SRG-OS-000080-GPOS-00048
     disa_stig:
+      macos_27:
+        - APPL-27-002001
       macos_26:
         - APPL-26-002001
       macos_15:
@@ -58,7 +60,10 @@ references:
       - 5.4
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/system_settings/system_settings_softwareupdate_current.yaml
+++ b/src/mscp/data/rules/system_settings/system_settings_softwareupdate_current.yaml
@@ -26,6 +26,8 @@ references:
     srg:
       - SRG-OS-000439-GPOS-00195
     disa_stig:
+      macos_27:
+        - APPL-27-999999
       macos_26:
         - APPL-26-999999
       macos_15:
@@ -51,7 +53,10 @@ references:
       - 7.4
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/system_settings/system_settings_system_wide_preferences_configure.yaml
+++ b/src/mscp/data/rules/system_settings/system_settings_system_wide_preferences_configure.yaml
@@ -28,6 +28,8 @@ references:
       - SRG-OS-000324-GPOS-00125
       - SRG-OS-000480-GPOS-00228
     disa_stig:
+      macos_27:
+        - APPL-27-002069
       macos_26:
         - APPL-26-002069
       macos_15:
@@ -59,7 +61,10 @@ references:
       - 4.1
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: high
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/system_settings/system_settings_time_server_configure.yaml
+++ b/src/mscp/data/rules/system_settings/system_settings_time_server_configure.yaml
@@ -34,6 +34,8 @@ references:
       - SRG-OS-000355-GPOS-00143
       - SRG-OS-000356-GPOS-00144
     disa_stig:
+      macos_27:
+        - APPL-27-000170
       macos_26:
         - APPL-26-000170
       macos_15:
@@ -57,7 +59,10 @@ references:
       - 8.4
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/system_settings/system_settings_time_server_enforce.yaml
+++ b/src/mscp/data/rules/system_settings/system_settings_time_server_enforce.yaml
@@ -31,6 +31,8 @@ references:
       - SRG-OS-000355-GPOS-00143
       - SRG-OS-000356-GPOS-00144
     disa_stig:
+      macos_27:
+        - APPL-27-000014
       macos_26:
         - APPL-26-000014
       macos_15:
@@ -54,7 +56,10 @@ references:
       - 8.4
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/mscp/data/rules/system_settings/system_settings_token_removal_enforce.yaml
+++ b/src/mscp/data/rules/system_settings/system_settings_token_removal_enforce.yaml
@@ -30,6 +30,8 @@ references:
     srg:
       - SRG-OS-000030-GPOS-00011
     disa_stig:
+      macos_27:
+        - APPL-27-000005
       macos_26:
         - APPL-26-000005
       macos_15:
@@ -40,7 +42,10 @@ references:
       - AC.L2-3.1.10
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/system_settings/system_settings_usb_restricted_mode.yaml
+++ b/src/mscp/data/rules/system_settings/system_settings_usb_restricted_mode.yaml
@@ -44,6 +44,8 @@ references:
       - SRG-OS-000378-GPOS-00163
       - SRG-OS-000690-GPOS-00140
     disa_stig:
+      macos_27:
+        - APPL-27-005090
       macos_26:
         - APPL-26-005090
       macos_15:
@@ -76,7 +78,10 @@ references:
       - 1.2      
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig

--- a/src/mscp/data/rules/system_settings/system_settings_wallet_applepay_settings_disable.yaml
+++ b/src/mscp/data/rules/system_settings/system_settings_wallet_applepay_settings_disable.yaml
@@ -28,6 +28,8 @@ references:
     srg:
       - SRG-OS-000095-GPOS-00049
     disa_stig:
+      macos_27:
+        - APPL-27-002052
       macos_26:
         - APPL-26-002052
       macos_15:
@@ -46,7 +48,10 @@ references:
       - 4.8
 platforms:
   macOS:
-    '27.0': {}
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: disa_stig


### PR DESCRIPTION
Added STIGIDs updated benchmark/severity info and updated password max lifetime to 180.