### PR TITLE
Fix excluded rules in JSON manifest

### DIFF
--- a/src/mscp/generate/guidance_support/manifest.py
+++ b/src/mscp/generate/guidance_support/manifest.py
@@ -63,6 +63,8 @@ def generate_manifest(build_path: Path, baseline_name: str, baseline) -> None:
     manifest["rules"] = []
     for profile in baseline.profile:
         for rule in profile.rules:
+            if rule.section == "Excluded Rules":
+                continue
             rule_manifest = {}
             rule_manifest["id"] = rule.rule_id
             rule_manifest["title"] = rule.title

--- a/tests/fixtures/manifest_with_excluded_rule.yaml
+++ b/tests/fixtures/manifest_with_excluded_rule.yaml
@@ -1,0 +1,15 @@
+---
+authors: []
+title: V164 manifest exclusion fixture
+description: Minimal included/excluded manifest fixture.
+platform:
+  os: macOS
+  version: 26.0
+parent_values: recommended
+profile:
+  - section: Operating System
+    rules:
+      - os_gatekeeper_enable
+  - section: Excluded
+    rules:
+      - os_airdrop_disable

--- a/tests/test_manifest_exclusions.py
+++ b/tests/test_manifest_exclusions.py
@@ -1,0 +1,71 @@
+"""Regression proof for excluded rules leaking into the JSON manifest."""
+
+from __future__ import annotations
+
+import json
+import plistlib
+from pathlib import Path
+
+import pytest
+
+from mscp.classes import Baseline
+from mscp.generate.guidance_support import generate_manifest, generate_profiles
+
+INCLUDED_RULE_ID = "os_gatekeeper_enable"
+EXCLUDED_RULE_ID = "os_airdrop_disable"
+FIXTURE_PATH = Path(__file__).parent / "fixtures" / "manifest_with_excluded_rule.yaml"
+
+
+@pytest.fixture(scope="module")
+def baseline_with_excluded_rule() -> Baseline:
+    """Load the smallest native baseline with one included and one excluded rule."""
+    return Baseline.from_yaml(FIXTURE_PATH)
+
+
+def test_from_yaml_preserves_excluded_classification(
+    baseline_with_excluded_rule: Baseline,
+) -> None:
+    sections = {
+        rule.rule_id: rule.section
+        for profile in baseline_with_excluded_rule.profile
+        for rule in profile.rules
+    }
+
+    assert sections[INCLUDED_RULE_ID] == "Operating System"
+    assert sections[EXCLUDED_RULE_ID] == "Excluded Rules"
+
+
+def test_manifest_omits_excluded_rules(
+    tmp_path: Path,
+    baseline_with_excluded_rule: Baseline,
+) -> None:
+    generate_manifest(tmp_path, "v164_manifest", baseline_with_excluded_rule)
+
+    manifest = json.loads((tmp_path / "v164_manifest.json").read_text())
+    rule_ids = [rule["id"] for rule in manifest["rules"]]
+
+    assert INCLUDED_RULE_ID in rule_ids
+    assert EXCLUDED_RULE_ID not in rule_ids
+
+
+def test_configuration_profiles_omit_excluded_rules(
+    tmp_path: Path,
+    baseline_with_excluded_rule: Baseline,
+) -> None:
+    generate_profiles(tmp_path, "v164_profiles", baseline_with_excluded_rule)
+
+    unsigned = tmp_path / "mobileconfigs" / "unsigned"
+    included_profile = unsigned / "com.apple.systempolicy.control.mobileconfig"
+    excluded_profile = unsigned / "com.apple.applicationaccess.mobileconfig"
+
+    assert included_profile.is_file()
+    assert not excluded_profile.exists()
+
+    with included_profile.open("rb") as profile_file:
+        generated = plistlib.load(profile_file)
+
+    assert any(
+        payload.get("PayloadType") == "com.apple.systempolicy.control"
+        and payload.get("EnableAssessment") is True
+        for payload in generated["PayloadContent"]
+    )


### PR DESCRIPTION
## Summary

- Skip rules in the `Excluded Rules` section when generating the JSON manifest.
- Add regression coverage showing included rules remain in the manifest while excluded rules are omitted.
- Keep the existing configuration-profile exclusion behavior unchanged.

Fixes #767

## Verification

- Focused exclusion regression: 3 passed
- Available test suite: 44 passed
- Focused Flake8 / Ruff / yamllint checks: passed
- `git diff --check`: passed

Repository-wide Flake8 still reports the two existing `F841` findings in `macsecurityrule.py`; both reproduce unchanged on the pristine base.

## AI assistance disclosure

I used OpenAI Codex to reproduce the issue, prepare the focused patch and regression tests, and run the verification. I reviewed the complete proposed change and take responsibility for the submission.