### PR TITLE
Implement Basic Schema Changes to Support Linux

### DIFF
--- a/src/mscp/common_utils/constants.py
+++ b/src/mscp/common_utils/constants.py
@@ -8,7 +8,7 @@ SCHEMA_PATH = "schema/mscp_rule.json"
 APPLE_OS = ["macos", "ios", "visionos"]
 
 #: Subset of `APPLE_OS` whose tooling expects POSIX-style commands.
-NIX_OS = ["macos"]
+NIX_OS = ["macos", "ubuntu", "redhat"]
 
 #: Platform map for identifiers
-PLATFORM_MAP = {"macos": "macOS", "ios": "iOS", "visionos": "visionOS"}
+PLATFORM_MAP = {"macos": "macOS", "ios": "iOS", "visionos": "visionOS", "ubuntu": "Ubuntu", "redhat": "Red Hat"}

--- a/src/mscp/data/includes/mscp-data.yaml
+++ b/src/mscp/data/includes/mscp-data.yaml
@@ -136,3 +136,23 @@ versions:
       - os_version: 26.0
         os_name: visionos_26
         cpe: o:apple:visionos:26.0
+    ubuntu:
+      - os_version: 22.04
+        os_name: 22.04 LTS
+        cpe: o:canonical:ubuntu_linux:22.04
+      - os_version: 24.04
+        os_name: 24.04 LTS
+        cpe: o:canonical:ubuntu_linux:24.04
+      - os_version: 26.04
+        os_name: 26.04 LTS
+        cpe: o:canonical:ubuntu_linux:26.04
+    redhat:
+      - os_version: 8
+        os_name: "8"
+        cpe: o:redhat:enterprise_linux:8.0
+      - os_version: 9
+        os_name: "9"
+        cpe: o:redhat:enterprise_linux:9.0
+      - os_version: 10
+        os_name: "10"
+        cpe: o:redhat:enterprise_linux:10.0

--- a/src/mscp/data/schema/mscp_rule.json
+++ b/src/mscp/data/schema/mscp_rule.json
@@ -318,6 +318,44 @@
                         }
                     },
                     "additionalProperties": false
+                },
+                "ubuntu": {
+                    "type": "object",
+                    "description": "Schema for identifying components to support Ubuntu Linux",
+                    "properties": {
+                        "enforcement_info": {
+                            "$ref": "#/$defs/enforcement_infoDef"
+                        },
+                        "22.04": {
+                            "$ref": "#/$defs/osDef"
+                        },
+                        "24.04": {
+                            "$ref": "#/$defs/osDef"
+                        },
+                        "26.04": {
+                            "$ref": "#/$defs/osDef"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "redhat": {
+                    "type": "object",
+                    "description": "Schema for identifying components to support Red Hat Enterprise Linux",
+                    "properties": {
+                        "enforcement_info": {
+                            "$ref": "#/$defs/enforcement_infoDef"
+                        },
+                        "8": {
+                            "$ref": "#/$defs/osDef"
+                        },
+                        "9": {
+                            "$ref": "#/$defs/osDef"
+                        },
+                        "10": {
+                            "$ref": "#/$defs/osDef"
+                        }
+                    },
+                    "additionalProperties": false
                 }
             }
         },


### PR DESCRIPTION
This commit adds basic Linux support to the mSCP.

The following changes are made:
- Updating the schema to include Ubuntu and Red Hat definitions with the supported platforms decided by the Linux Security Compliance Project (LSCP) maintainers.
- Ensuring the platform mappings and "NIX OS" categorization correctly include Linux definitions.
- Adding additional information for OS indexing, including references to the relevant NIST CPEs for each OS version.

As the LSCP is in early development, only the minimum changes necessary to allow mSCP tooling to work with the project were completed here. Additional changes, such as adding conditionals for every mention of "macOS" or "Apple" in the templates, were not dealt with, as further discussions needs to happen regarding the "separation" each project will have in the future.