### PR TITLE
Allow Exit Codes To Be Used For Compliance Checking

### DIFF
--- a/src/mscp/classes/enforcement_info.py
+++ b/src/mscp/classes/enforcement_info.py
@@ -24,6 +24,7 @@ class ResultDef(BaseModelWithAccessors):
     string: Optional[str] = None
     integer: Optional[Union[int, ODV]] = None
     boolean: Optional[bool] = None
+    exit_code: Optional[int] = None
 
 
 class ShellCheck(BaseModelWithAccessors):

--- a/src/mscp/classes/macsecurityrule.py
+++ b/src/mscp/classes/macsecurityrule.py
@@ -127,6 +127,7 @@ class Macsecurityrule(BaseModelWithAccessors):
     odv: dict[str, Any] | None = None
     tags: list[str] = Field(default_factory=list)
     result_value: str | int | bool | None = None
+    result_exit_code: int | None = None
     mobileconfig_info: list[Mobileconfigpayload] | None = None
     ddm_info: dict[str, Any] | None = None
     customized: list[str] = Field(default_factory=list)
@@ -218,6 +219,7 @@ class Macsecurityrule(BaseModelWithAccessors):
             logger.debug("Transforming rule: {}", rule_id)
 
             result_value: str | int | bool | None = None
+            exit_code: int | None = None
             check_value: str | None = None
             fix_value: str | None = None
             default_state_value: str | None = None
@@ -303,7 +305,10 @@ class Macsecurityrule(BaseModelWithAccessors):
 
                 if check_result:
                     for k, v in enforcement_info["check"]["result"].items():
-                        if isinstance(v, (int, bool, str)):
+                        if k == "exit_code":
+                            exit_code = v
+                            break
+                        elif isinstance(v, (int, bool, str)):
                             result_value = v
                             break
                         elif k == "base64":
@@ -460,6 +465,7 @@ class Macsecurityrule(BaseModelWithAccessors):
                 rule = cls(
                     **rule_yaml,
                     result_value=result_value,
+                    result_exit_code=exit_code,
                     customized=customized_fields,
                     mobileconfig_info=payloads,
                     mechanism=mechanism,

--- a/src/mscp/data/schema/mscp_rule.json
+++ b/src/mscp/data/schema/mscp_rule.json
@@ -512,6 +512,9 @@
                 },
                 "boolean": {
                     "type": "boolean"
+                },
+                "exit_code": {
+                    "type": "integer"
                 }
             }
         },

--- a/src/mscp/data/templates/documents/markdown/rule.md.jinja
+++ b/src/mscp/data/templates/documents/markdown/rule.md.jinja
@@ -35,7 +35,11 @@
 {% endif %}
 
 {% if rule.os_type.lower() in NIX_OS %}
+{% if rule.result_value is not none %}
 {% trans %}If the result is not{% endtrans %} _{{ rule.result_value }}_, {% trans %}this is a finding{% endtrans %}.
+{% elif rule.result_exit_code is not none %}
+{% trans %}If the command's exit code is not{% endtrans %} _{{ rule.result_exit_code }}_, {% trans %}this is a finding{% endtrans %}.
+{% endif %}
 {% endif %}
 
 {% if markdown_tree | default(false) %}


### PR DESCRIPTION
Utilizing exit codes requires modifying the schema to allow rules with a specified exit code to pass validation. Other than that, minimal changes to the Macsecurityrule class were made to ensure the exit code is stored into a separate variable that then gets passed to templates. To provide an example of the change, the markdown template was modified to display different text if the result value is an exit code compared to regular command output.

This is a request of the Linux Security Compliance Project.