### PR TITLE
Updated to use correct keys

### DIFF
--- a/src/mscp/data/rules/os/os_on_device_dictation_enforce.yaml
+++ b/src/mscp/data/rules/os/os_on_device_dictation_enforce.yaml
@@ -179,5 +179,5 @@ mobileconfig_info:
       - forceOnDeviceOnlyDictation: true
 ddm_info:
   declarationtype: com.apple.configuration.intelligence.settings
-  ddm_key: ForceOnDeviceOnlyTranslation
+  ddm_key: ForceOnDeviceOnlyDictation
   ddm_value: true

--- a/src/mscp/data/rules/os/os_on_device_translation_enforce.yaml
+++ b/src/mscp/data/rules/os/os_on_device_translation_enforce.yaml
@@ -97,4 +97,4 @@ mobileconfig_info:
 ddm_info:
   declarationtype: com.apple.configuration.intelligence.settings
   ddm_key: ForceOnDeviceOnlyTranslation
-  ddm_value: false
+  ddm_value: true


### PR DESCRIPTION
Updates `os_on_device_dictation_enforce` and `os_on_device_translation_enforce` to use the correct key/values