### PR TITLE
NIST Pages: macOS 27 Support & Markdown Release Notes

### DIFF
--- a/public/scripts/github-latest-release.js
+++ b/public/scripts/github-latest-release.js
@@ -7,20 +7,192 @@ const GITHUB_OWNER = 'usnistgov';
 const GITHUB_REPO = 'macos_security';
 const CONTAINER_ID = 'github-latest-release';
 
+// --- Minimal GitHub-flavored Markdown renderer for release notes ---
+
+const REPO_URL_PREFIX = `https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}/`;
+const KEEP = '\u0000';
+
+function escapeHtml(text) {
+  return String(text)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+// Shorten links back to this repo the way GitHub does: pull/751 -> #751
+function linkLabel(url) {
+  if (url.indexOf(REPO_URL_PREFIX) === 0) {
+    const rest = url.slice(REPO_URL_PREFIX.length);
+    const issue = rest.match(/^(?:pull|issues)\/(\d+)$/);
+    if (issue) return '#' + issue[1];
+    const compare = rest.match(/^compare\/(.+)$/);
+    if (compare) return compare[1];
+  }
+  return url;
+}
+
+function anchor(url, label) {
+  return `<a href="${url}" target="_blank" rel="noopener">${label}</a>`;
+}
+
+function renderInline(text) {
+  const kept = [];
+  const keep = (html) => KEEP + (kept.push(html) - 1) + KEEP;
+
+  let s = escapeHtml(text);
+
+  // `code` — protected first so nothing below rewrites its contents
+  s = s.replace(/`([^`]+)`/g, (_, code) => keep(`<code>${code}</code>`));
+
+  // [label](url) — keep only the tags so the label still picks up bold/italic
+  s = s.replace(
+    new RegExp('\\[([^\\]' + KEEP + ']+)\\]\\((https?:\\/\\/[^\\s)]+)\\)', 'g'),
+    (_, label, url) => keep(`<a href="${url}" target="_blank" rel="noopener">`) + label + keep('</a>')
+  );
+
+  // Bare URLs
+  s = s.replace(new RegExp('(^|[\\s(])(https?:\\/\\/[^\\s<>()' + KEEP + ']+)', 'g'), (_, before, url) => {
+    const trailing = (url.match(/[.,;:!?]+$/) || [''])[0];
+    if (trailing) url = url.slice(0, -trailing.length);
+    return before + keep(anchor(url, linkLabel(url))) + trailing;
+  });
+
+  s = s.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+  s = s.replace(/__([^_]+)__/g, '<strong>$1</strong>');
+  s = s.replace(/\*([^*\n]+)\*/g, '<em>$1</em>');
+  // Underscore italics need word boundaries so snake_case names survive
+  s = s.replace(/(^|[\s(])_([^_\n]+)_(?=$|[\s).,;:!?])/g, '$1<em>$2</em>');
+  s = s.replace(/~~([^~]+)~~/g, '<del>$1</del>');
+
+  // @mentions, including @dependabot[bot]
+  s = s.replace(
+    /(^|[^\w\/@])@([A-Za-z\d][A-Za-z\d-]{0,38})(\[bot\])?/g,
+    (_, before, user, bot) => before + anchor(`https://github.com/${user}`, '@' + user + (bot || ''))
+  );
+
+  return s.replace(new RegExp(KEEP + '(\\d+)' + KEEP, 'g'), (_, i) => kept[i]);
+}
+
+function renderMarkdown(md) {
+  const lines = String(md).replace(/\r\n?/g, '\n').split('\n');
+  const out = [];
+  const listStack = [];
+  let para = [];
+  let quote = [];
+  let fence = null;
+
+  const flushPara = () => {
+    if (!para.length) return;
+    out.push(`<p>${para.map(renderInline).join('<br>')}</p>`);
+    para = [];
+  };
+  const flushQuote = () => {
+    if (!quote.length) return;
+    out.push(`<blockquote>${renderMarkdown(quote.join('\n'))}</blockquote>`);
+    quote = [];
+  };
+  const closeLists = () => {
+    while (listStack.length) out.push(`</li></${listStack.pop().tag}>`);
+  };
+  const flushBlocks = () => {
+    flushPara();
+    flushQuote();
+    closeLists();
+  };
+
+  for (const line of lines) {
+    const fenceMark = /^\s*(?:```|~~~)/.test(line);
+    if (fence) {
+      if (fenceMark) {
+        out.push(`<pre><code>${escapeHtml(fence.join('\n'))}</code></pre>`);
+        fence = null;
+      } else {
+        fence.push(line);
+      }
+      continue;
+    }
+    if (fenceMark) {
+      flushBlocks();
+      fence = [];
+      continue;
+    }
+
+    if (!line.trim()) {
+      flushBlocks();
+      continue;
+    }
+
+    const quoted = line.match(/^\s*>\s?(.*)$/);
+    if (quoted) {
+      flushPara();
+      closeLists();
+      quote.push(quoted[1]);
+      continue;
+    }
+    flushQuote();
+
+    const heading = line.match(/^(#{1,6})\s+(.*)$/);
+    if (heading) {
+      flushBlocks();
+      // Offset so a release note's "## Section" sits under the page's own h2
+      const level = Math.min(heading[1].length + 2, 6);
+      out.push(`<h${level}>${renderInline(heading[2].replace(/\s+#+\s*$/, ''))}</h${level}>`);
+      continue;
+    }
+
+    if (/^\s*(?:[-*_]\s*){3,}$/.test(line)) {
+      flushBlocks();
+      out.push('<hr>');
+      continue;
+    }
+
+    const item = line.match(/^(\s*)(?:([-*+])|(\d+)[.)])\s+(.*)$/);
+    if (item) {
+      flushPara();
+      const indent = item[1].replace(/\t/g, '  ').length;
+      const tag = item[2] ? 'ul' : 'ol';
+      while (listStack.length && listStack[listStack.length - 1].indent > indent) {
+        out.push(`</li></${listStack.pop().tag}>`);
+      }
+      const top = listStack[listStack.length - 1];
+      if (top && top.indent === indent) {
+        out.push('</li>');
+        if (top.tag !== tag) {
+          out.push(`</${listStack.pop().tag}>`);
+          out.push(`<${tag}>`);
+          listStack.push({ tag, indent });
+        }
+      } else {
+        out.push(`<${tag}>`);
+        listStack.push({ tag, indent });
+      }
+      out.push(`<li>${renderInline(item[4])}`);
+      continue;
+    }
+
+    // A wrapped line inside a list item, otherwise ordinary paragraph text
+    if (listStack.length && /^\s{2,}/.test(line)) {
+      out.push(`<br>${renderInline(line.trim())}`);
+      continue;
+    }
+    closeLists();
+    para.push(line.trim());
+  }
+
+  if (fence) out.push(`<pre><code>${escapeHtml(fence.join('\n'))}</code></pre>`);
+  flushBlocks();
+  return out.join('');
+}
+
 function renderReleaseInfo({ tag_name, name, html_url, published_at, body }) {
   const date = published_at
     ? new Date(published_at).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
     : '';
 
   let notes = '';
-  if (body) {
-    notes = body.replace(/</g, "&lt;");
-    notes = notes.replace(
-      /\*\*Full Changelog\*\*:\s*(https?:\/\/[^\s]+)/g,
-      (match, url) =>
-        `<a href="${url}" target="_blank" rel="noopener">Full Changelog</a>`
-    );
-    notes = `<div class="github-release-notes">${notes}</div>`;
+  if (body && body.trim()) {
+    notes = `<div class="github-release-notes">${renderMarkdown(body)}</div>`;
   }
   return `
     <div class="github-release-info">
@@ -32,9 +204,9 @@ function renderReleaseInfo({ tag_name, name, html_url, published_at, body }) {
         </svg>
         <div class="github-release-title-group">
           <a href="${html_url}" target="_blank" rel="noopener" class="github-release-title">
-            ${name || tag_name}
+            ${escapeHtml(name || tag_name)}
           </a>
-          <span class="github-release-tag">${tag_name}</span>
+          <span class="github-release-tag">${escapeHtml(tag_name)}</span>
         </div>
       </div>
       ${date ? `<div class="github-release-date">Released: <strong>${date}</strong></div>` : ''}
@@ -164,11 +336,11 @@ function injectReleaseBoxStyles() {
     .github-release-notes {
       margin-top: 0.75em;
       font-size: 0.95em;
+      line-height: 1.6;
       color: var(--sl-color-text, #444);
-      white-space: pre-line;
       overflow-wrap: anywhere;
       word-break: break-word;
-      padding: 0.75em;
+      padding: 0.75em 1em;
       background: rgba(0,0,0,0.015);
       border-radius: 6px;
       border: 1px solid rgba(0,0,0,0.04);
@@ -176,6 +348,86 @@ function injectReleaseBoxStyles() {
     [data-theme="dark"] .github-release-notes {
       background: rgba(255,255,255,0.02);
       border-color: rgba(255,255,255,0.05);
+    }
+    .github-release-notes > :first-child {
+      margin-top: 0;
+    }
+    .github-release-notes > :last-child {
+      margin-bottom: 0;
+    }
+    .github-release-notes :is(h3, h4, h5, h6) {
+      margin: 1.25em 0 0.5em;
+      font-size: 1em;
+      font-weight: 600;
+      line-height: 1.3;
+      color: var(--sl-color-white, #111);
+    }
+    .github-release-notes p {
+      margin: 0.6em 0;
+    }
+    .github-release-notes :is(ul, ol) {
+      margin: 0.5em 0;
+      padding-left: 1.4em;
+      list-style-position: outside;
+    }
+    .github-release-notes ul {
+      list-style-type: disc;
+    }
+    .github-release-notes ol {
+      list-style-type: decimal;
+    }
+    .github-release-notes li {
+      margin: 0.2em 0;
+    }
+    .github-release-notes :is(ul, ol) :is(ul, ol) {
+      margin: 0.2em 0;
+    }
+    .github-release-notes a {
+      color: var(--sl-color-accent, #316431);
+      text-decoration: none;
+    }
+    .github-release-notes a:hover {
+      text-decoration: underline;
+    }
+    [data-theme="dark"] .github-release-notes a {
+      color: var(--sl-color-accent-high, #6ab549);
+    }
+    .github-release-notes code {
+      font-size: 0.9em;
+      padding: 0.15em 0.4em;
+      border-radius: 4px;
+      background: rgba(0,0,0,0.06);
+    }
+    [data-theme="dark"] .github-release-notes code {
+      background: rgba(255,255,255,0.1);
+    }
+    .github-release-notes pre {
+      margin: 0.6em 0;
+      padding: 0.75em;
+      overflow-x: auto;
+      border-radius: 6px;
+      background: rgba(0,0,0,0.05);
+    }
+    [data-theme="dark"] .github-release-notes pre {
+      background: rgba(255,255,255,0.06);
+    }
+    .github-release-notes pre code {
+      padding: 0;
+      background: none;
+      white-space: pre;
+      overflow-wrap: normal;
+      word-break: normal;
+    }
+    .github-release-notes blockquote {
+      margin: 0.6em 0;
+      padding-left: 0.9em;
+      border-left: 3px solid var(--sl-color-gray-5, #ddd);
+      color: var(--sl-color-gray-2, #666);
+    }
+    .github-release-notes hr {
+      margin: 1em 0;
+      border: 0;
+      border-top: 1px solid var(--sl-color-gray-5, #ddd);
     }
     .github-release-links {
       display: flex;

--- a/src/content/docs/baselines/how-to-generate-baselines.mdx
+++ b/src/content/docs/baselines/how-to-generate-baselines.mdx
@@ -33,7 +33,7 @@ Generating a baseline creates the YAML file that defines which security rules ap
    Example:
    ```bash
    ./mscp.py baseline -k 800-53r5_moderate
-   # Output: Generated new baseline file: config/custom/baselines/800-53r5_moderate_macos_26.0.yaml
+   # Output: Generated new baseline file: config/custom/baselines/800-53r5_moderate_macos_27.0.yaml
    ```
 
 3. **Find your file**

--- a/src/content/docs/compliance-scripts/how-to-generate-compliance-scripts.mdx
+++ b/src/content/docs/compliance-scripts/how-to-generate-compliance-scripts.mdx
@@ -30,7 +30,7 @@ You need a baseline first. See <a href={`${base}baselines/how-to-generate-baseli
 
    Example:
    ```bash
-   ./mscp.py guidance custom/baselines/800-53r5_moderate_macos_26.0.yaml -s
+   ./mscp.py guidance custom/baselines/800-53r5_moderate_macos_27.0.yaml -s
    ```
 
 2. **Find your files**
@@ -39,13 +39,13 @@ You need a baseline first. See <a href={`${base}baselines/how-to-generate-baseli
 
    <FileTree>
    - build/
-       - 800-53r5_moderate_macos_26.0/
-           - 800-53r5_moderate_macos_26.0_compliance.sh Compliance script
-           - 800-53r5_moderate_macos_26.0.adoc AsciiDoc guidance
-           - 800-53r5_moderate_macos_26.0.html HTML guidance
-           - 800-53r5_moderate_macos_26.0.pdf PDF guidance
+       - 800-53r5_moderate_macos_27.0/
+           - 800-53r5_moderate_macos_27.0_compliance.sh Compliance script
+           - 800-53r5_moderate_macos_27.0.adoc AsciiDoc guidance
+           - 800-53r5_moderate_macos_27.0.html HTML guidance
+           - 800-53r5_moderate_macos_27.0.pdf PDF guidance
            - preferences/
-               - org.800-53r5_moderate_macos_26.0.audit.plist
+               - org.800-53r5_moderate_macos_27.0.audit.plist
    </FileTree>
 
 </Steps>
@@ -101,7 +101,7 @@ Run with sudo for full access to system settings:
 
 
 ```zsh
-sudo ./build/800-53r5_moderate_macos_26.0/800-53r5_moderate_macos_26.0_compliance.sh
+sudo ./build/800-53r5_moderate_macos_27.0/800-53r5_moderate_macos_27.0_compliance.sh
 ```
 
   </TabItem>

--- a/src/content/docs/configuration-profiles/how-to-generate-configuration-profiles.mdx
+++ b/src/content/docs/configuration-profiles/how-to-generate-configuration-profiles.mdx
@@ -30,7 +30,7 @@ You need a baseline first. See <a href={`${base}baselines/how-to-generate-baseli
 
    Example:
    ```bash
-   ./mscp.py guidance custom/baselines/800-53r5_moderate_macos_26.0.yaml -p
+   ./mscp.py guidance custom/baselines/800-53r5_moderate_macos_27.0.yaml -p
    ```
 
 2. **Find your files**
@@ -39,7 +39,7 @@ You need a baseline first. See <a href={`${base}baselines/how-to-generate-baseli
 
    <FileTree>
    - build/
-       - 800-53r5_moderate_macos_26.0/
+       - 800-53r5_moderate_macos_27.0/
            - mobileconfigs/
                - unsigned/ Unsigned profiles (.mobileconfig)
                - preferences/ Preference plists (.plist)
@@ -125,7 +125,7 @@ Replace `"Your Certificate Name"` with your signing certificate's common name.
 
 Example:
 ```bash
-./mscp.py guidance custom/baselines/800-53r5_moderate_macos_26.0.yaml -p -H ABC123DEF456
+./mscp.py guidance custom/baselines/800-53r5_moderate_macos_27.0.yaml -p -H ABC123DEF456
 ```
 
   </TabItem>

--- a/src/content/docs/ddm-components/how-to-generate-ddm-components.mdx
+++ b/src/content/docs/ddm-components/how-to-generate-ddm-components.mdx
@@ -30,7 +30,7 @@ You need a baseline first. See <a href={`${base}baselines/how-to-generate-baseli
 
    Example:
    ```bash
-   ./mscp.py guidance custom/baselines/800-53r5_moderate_macos_26.0.yaml -d
+   ./mscp.py guidance custom/baselines/800-53r5_moderate_macos_27.0.yaml -d
    ```
 
 2. **Find your files**
@@ -39,7 +39,7 @@ You need a baseline first. See <a href={`${base}baselines/how-to-generate-baseli
 
    <FileTree>
    - build/
-       - 800-53r5_moderate_macos_26.0/
+       - 800-53r5_moderate_macos_27.0/
            - activations/ Activation declarations (.json)
            - configurations/ Configuration declarations (.json)
            - assets/ Asset declarations and data files (.json, .zip)

--- a/src/content/docs/guidance/how-to-generate-guidance.mdx
+++ b/src/content/docs/guidance/how-to-generate-guidance.mdx
@@ -26,20 +26,20 @@ Generating guidance creates outputs from your baseline. By default it generates 
 
    Example:
    ```bash
-   ./mscp.py guidance custom/baselines/800-53r5_moderate_macos_26.0.yaml
+   ./mscp.py guidance custom/baselines/800-53r5_moderate_macos_27.0.yaml
    ```
 
 2. **Add flags for additional outputs**
 
    ```bash
-   ./mscp.py guidance custom/baselines/800-53r5_moderate_macos_26.0.yaml -s -p
+   ./mscp.py guidance custom/baselines/800-53r5_moderate_macos_27.0.yaml -s -p
    ```
 
    This generates guidance docs plus compliance script (`-s`) and configuration profiles (`-p`).
 
    Generate all outputs at once with `-A`:
    ```bash
-   ./mscp.py guidance custom/baselines/800-53r5_moderate_macos_26.0.yaml -A
+   ./mscp.py guidance custom/baselines/800-53r5_moderate_macos_27.0.yaml -A
    ```
 
 3. **Find your files**
@@ -48,13 +48,13 @@ Generating guidance creates outputs from your baseline. By default it generates 
 
    <FileTree>
    - build/
-       - 800-53r5_moderate_macos_26.0/
-           - **800-53r5_moderate_macos_26.0.adoc** AsciiDoc source
-           - **800-53r5_moderate_macos_26.0.html** Web documentation
-           - **800-53r5_moderate_macos_26.0.pdf** Printable documentation
-           - **800-53r5_moderate_macos_26.0.md** Markdown (if -m)
-           - **800-53r5_moderate_macos_26.0_compliance.sh** Compliance script (if -s)
-           - **800-53r5_moderate_macos_26.0.xlsx** Excel spreadsheet (if -x)
+       - 800-53r5_moderate_macos_27.0/
+           - **800-53r5_moderate_macos_27.0.adoc** AsciiDoc source
+           - **800-53r5_moderate_macos_27.0.html** Web documentation
+           - **800-53r5_moderate_macos_27.0.pdf** Printable documentation
+           - **800-53r5_moderate_macos_27.0.md** Markdown (if -m)
+           - **800-53r5_moderate_macos_27.0_compliance.sh** Compliance script (if -s)
+           - **800-53r5_moderate_macos_27.0.xlsx** Excel spreadsheet (if -x)
            - mobileconfigs/ Configuration profiles (if -p)
            - activations/ DDM components (if -d)
            - configurations/
@@ -191,37 +191,37 @@ The `main` branch is now used for **mSCP 2.0** and will generate content using t
 
 **Generate all outputs:**
 ```bash
-./mscp.py guidance custom/baselines/800-53r5_moderate_macos_26.0.yaml -A
+./mscp.py guidance custom/baselines/800-53r5_moderate_macos_27.0.yaml -A
 ```
 
 **Generate documentation only:**
 ```bash
-./mscp.py guidance custom/baselines/800-53r5_moderate_macos_26.0.yaml
+./mscp.py guidance custom/baselines/800-53r5_moderate_macos_27.0.yaml
 ```
 
 **Generate everything for MDM deployment:**
 ```bash
-./mscp.py guidance custom/baselines/DISA-STIG_macos_26.0.yaml -s -p -d
+./mscp.py guidance custom/baselines/DISA-STIG_macos_27.0.yaml -s -p -d
 ```
 
 **Generate with signed profiles:**
 ```bash
-./mscp.py guidance custom/baselines/cis_lvl2_macos_26.0.yaml -p -H YOUR_CERT_HASH
+./mscp.py guidance custom/baselines/cis_lvl2_macos_27.0.yaml -p -H YOUR_CERT_HASH
 ```
 
 **Generate documentation with custom logo:**
 ```bash
-./mscp.py guidance custom/baselines/800-53r5_moderate_macos_26.0.yaml -l /path/to/logo.png
+./mscp.py guidance custom/baselines/800-53r5_moderate_macos_27.0.yaml -l /path/to/logo.png
 ```
 
 **Generate Markdown output:**
 ```bash
-./mscp.py guidance custom/baselines/800-53r5_moderate_macos_26.0.yaml -m
+./mscp.py guidance custom/baselines/800-53r5_moderate_macos_27.0.yaml -m
 ```
 
 **Generate documentation in a specific language:**
 ```bash
-./mscp.py guidance custom/baselines/800-53r5_moderate_macos_26.0.yaml -L de
+./mscp.py guidance custom/baselines/800-53r5_moderate_macos_27.0.yaml -L de
 ```
 
 The default language is English (`en`). Available languages are determined by the locales present in `config/locales/`. See <a href={`${base}other/generate-localization/`}>Generate Localization</a> for how to create and compile translation files.

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -26,14 +26,14 @@ export const base = import.meta.env.BASE_URL.endsWith('/') ? import.meta.env.BAS
 
 <div class="mscp2-promo">
   <div class="mscp2-promo-eyebrow">
-    mSCP 2.0 Has Arrived <span class="mscp2-promo-badge">New</span>
+    macOS 27 Support Is Here <span class="mscp2-promo-badge">New</span>
   </div>
-  <div class="mscp2-promo-title">mSCP 2.0 — The Next Generation</div>
-  <p class="mscp2-promo-desc">mSCP just got a whole lot better. One unified branch covers macOS, iOS/iPadOS, and visionOS. No more version juggling. Everything you need, in one place. Now officially available on the main branch.</p>
+  <div class="mscp2-promo-title">macOS 27 — Supported by mSCP 2.0</div>
+  <p class="mscp2-promo-desc">mSCP 2.0 supports macOS 27, available now on the main branch. Updated rules, baselines, and benchmarks are ready to use — alongside continued support for iOS/iPadOS and visionOS, all from one unified branch.</p>
   <ul class="mscp2-promo-features">
-    <li>Unified branch for all Apple OS versions</li>
+    <li>macOS 27 rules, baselines, and benchmarks</li>
+    <li>One unified branch for macOS, iOS/iPadOS, and visionOS</li>
     <li>Container support (no more local dependencies)</li>
-    <li>Modern command-line tooling</li>
     <li>Baselines, guidance, profiles, and scripts — all in one place</li>
   </ul>
   <div class="mscp2-promo-actions">
@@ -45,85 +45,6 @@ export const base = import.meta.env.BASE_URL.endsWith('/') ? import.meta.env.BAS
 ## Latest Release
 <div id="github-latest-release"></div>
 <script src={`${base}scripts/github-latest-release.js`}></script>
-
-## mSCP Branches
-<div id="github-branch-table">Loading branch information...</div>
-
-<script>
-{`
-(function() {
-  var GITHUB_OWNER = 'usnistgov';
-  var GITHUB_REPO = 'macos_security';
-  var BRANCHES = [
-    { name: 'main', display: 'Main', macOS: 'Unified Branch', current: true, version: '2.0' },
-    { name: 'tahoe', display: 'Tahoe', macOS: 'macOS 26', current: true, version: '1.0' },
-    { name: 'sequoia', display: 'Sequoia', macOS: 'macOS 15', current: false, version: '1.0' },
-    { name: 'sonoma', display: 'Sonoma', macOS: 'macOS 14', current: false, version: '1.0' }
-  ];
-
-  function formatDate(dateString) {
-    if (!dateString) return 'N/A';
-    return new Date(dateString).toLocaleDateString(undefined, {
-      year: 'numeric', month: 'short', day: 'numeric'
-    });
-  }
-
-  function fetchBranchInfo(branchName) {
-    return fetch('https://api.github.com/repos/' + GITHUB_OWNER + '/' + GITHUB_REPO + '/branches/' + branchName)
-      .then(function(res) { return res.ok ? res.json() : null; })
-      .then(function(data) {
-        if (!data) return null;
-        return { lastCommit: data.commit && data.commit.commit && data.commit.commit.author && data.commit.commit.author.date };
-      })
-      .catch(function() { return null; });
-  }
-
-  function renderBranches(branchData) {
-    var items = branchData.map(function(b) {
-      var color = b.version === '2.0' ? '#316431' : '#2f6fb0';
-      var versionBadge = b.version ? '<span style="background:' + color + ';color:#fff;font-size:0.75em;font-weight:700;padding:0.15em 0.5em;border-radius:4px;margin-left:0.45em;letter-spacing:0.02em;">' + b.version + '</span>' : '';
-      var currentBadge = b.current ? '<span style="background:' + color + ';color:#fff;font-size:0.75em;font-weight:700;padding:0.15em 0.5em;border-radius:4px;margin-left:0.45em;letter-spacing:0.02em;">Current</span>' : '';
-      var badge = currentBadge + versionBadge;
-      var date = b.info ? formatDate(b.info.lastCommit) : '...';
-      return '<span class="branch-group"><a href="https://github.com/' + GITHUB_OWNER + '/' + GITHUB_REPO + '/tree/' + b.name + '" target="_blank" rel="noopener" class="branch-card"><span style="font-weight:600;color:var(--sl-color-white);">' + b.display + '</span>' + badge + '<span class="sep">·</span><span class="meta">' + b.macOS + '</span><span class="sep">·</span><span class="meta">' + date + '</span></a><a href="https://github.com/' + GITHUB_OWNER + '/' + GITHUB_REPO + '/commits/' + b.name + '" target="_blank" rel="noopener" class="changelog-btn" title="View changelog"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg></a></span>';
-    }).join('');
-    return '<div style="display:flex;flex-wrap:wrap;gap:0.5em;justify-content:center;">' + items + '</div>' +
-      '<style>' +
-      '.branch-group{display:inline-flex;align-items:stretch;margin:0 !important;}' +
-      '.branch-group *{margin:0 !important;}' +
-      '.branch-card{display:inline-flex;align-items:center;gap:0.5em;padding:0.4em 0.7em;background:transparent;text-decoration:none;font-size:0.85em;border:1px solid var(--sl-color-gray-5);border-left:3px solid #316431;border-radius:6px 0 0 6px;transition:border-color 0.15s ease;}' +
-      '.branch-card:hover{border-color:#316431;border-left-color:#316431;}' +
-      '[data-theme="dark"] .branch-card{border-left-color:#6ab549;}' +
-      '[data-theme="dark"] .branch-card:hover{border-color:#6ab549;}' +
-      '.changelog-btn{display:inline-flex;align-items:center;padding:0.4em 0.5em;background:transparent;text-decoration:none;font-size:0.85em;color:var(--sl-color-gray-2);border:1px solid var(--sl-color-gray-5);border-radius:0 6px 6px 0;margin-left:-1px;transition:all 0.15s ease;position:relative;}' +
-      '.changelog-btn:hover{border-color:#316431;color:#316431;z-index:1;}' +
-      '[data-theme="dark"] .changelog-btn:hover{border-color:#6ab549;color:#6ab549;}' +
-      '.sep{color:var(--sl-color-gray-3);}' +
-      '.meta{color:var(--sl-color-gray-2);}' +
-      '</style>';
-  }
-
-  function loadTable() {
-    var container = document.getElementById('github-branch-table');
-    if (!container) return;
-    var initialData = BRANCHES.map(function(b) { return Object.assign({}, b, { info: null }); });
-    container.innerHTML = renderBranches(initialData);
-    var promises = BRANCHES.map(function(branch) {
-      return fetchBranchInfo(branch.name).then(function(info) {
-        return Object.assign({}, branch, { info: info });
-      });
-    });
-    Promise.all(promises).then(function(data) { container.innerHTML = renderBranches(data); });
-  }
-
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', loadTable);
-  } else {
-    loadTable();
-  }
-})();
-`}
-</script>
 
 ## Quick Links
 <CardGrid cols={3}>

--- a/src/content/docs/mscp-2/overview.mdx
+++ b/src/content/docs/mscp-2/overview.mdx
@@ -22,7 +22,7 @@ mSCP 2.0 is a major architectural evolution — a **unified codebase** that elim
   <div class="feature-box" style="flex: 1 1 calc(50% - 0.5rem); min-width: 250px; padding: 1.25rem; background: linear-gradient(135deg, var(--sl-color-blue-low) 0%, var(--sl-color-blue-low) 100%); border-radius: 12px; border: 1px solid var(--sl-color-blue); margin: 0 !important;">
     <div style="font-size: 2rem; margin-bottom: 0.75rem;">📋</div>
     <strong style="display: block; margin-bottom: 0.5rem; font-size: 1.1rem; color: var(--sl-color-blue-high);">Multi-Version Rules</strong>
-    <span style="font-size: 0.9rem; line-height: 1.5;">Each rule contains configs for macOS 14, 15, 26+ in one file.</span>
+    <span style="font-size: 0.9rem; line-height: 1.5;">Each rule contains configs for macOS 15, 26, and 27 in one file.</span>
   </div>
   <div class="feature-box" style="flex: 1 1 calc(50% - 0.5rem); min-width: 250px; padding: 1.25rem; background: linear-gradient(135deg, var(--sl-color-purple-low) 0%, var(--sl-color-purple-low) 100%); border-radius: 12px; border: 1px solid var(--sl-color-purple); margin: 0 !important;">
     <div style="font-size: 2rem; margin-bottom: 0.75rem;">🗂️</div>
@@ -68,17 +68,21 @@ references:
 references:
   nist:
     cce:
+      macos_27: [CCE-97025-1]
       macos_26: [CCE-95195-4]
       macos_15: [CCE-94195-5]
-      macos_14: [CCE-92795-4]
   disa:
     disa_stig:
+      macos_27: [APPL-27-002064]
       macos_26: [APPL-26-002064]
       macos_15: [APPL-15-002064]
-      macos_14: [APPL-14-002064]
 
 platforms:
   macOS:
+    '27.0':
+      benchmarks:
+        - name: disa_stig
+          severity: high
     '26.0':
       benchmarks:
         - name: disa_stig
@@ -202,11 +206,11 @@ The easiest way to get started — no local dependencies required.
    ```bash
    # Create a baseline
    ./mscp.py baseline -k cis_lvl1
-   # Output: Generated new baseline file: config/custom/baselines/cis_lvl1_macos_26.0.yaml
+   # Output: Generated new baseline file: config/custom/baselines/cis_lvl1_macos_27.0.yaml
 
    # Generate guidance with all outputs
-   ./mscp.py guidance custom/baselines/cis_lvl1_macos_26.0.yaml -A
-   # Output: MSCP DOCUMENT GENERATION COMPLETE! All documents in: /build/cis_lvl1_macos_26.0/
+   ./mscp.py guidance custom/baselines/cis_lvl1_macos_27.0.yaml -A
+   # Output: MSCP DOCUMENT GENERATION COMPLETE! All documents in: /build/cis_lvl1_macos_27.0/
    ```
 
 </Steps>
@@ -285,7 +289,7 @@ dependency, so there is nothing extra to set up.
    ./mscp.py baseline -k cis_lvl1
 
    # Generate guidance with all outputs
-   ./mscp.py guidance custom/baselines/cis_lvl1_macos_26.0.yaml -A
+   ./mscp.py guidance custom/baselines/cis_lvl1_macos_27.0.yaml -A
 
    # When done, deactivate the virtual environment
    deactivate

--- a/src/content/docs/other/generate-localization.mdx
+++ b/src/content/docs/other/generate-localization.mdx
@@ -46,7 +46,7 @@ Localization is only available in mSCP 2.0.
 4. **Generate guidance in your language**
 
    ```bash
-   ./mscp.py guidance custom/baselines/800-53r5_moderate_macos_26.0.yaml -L de
+   ./mscp.py guidance custom/baselines/800-53r5_moderate_macos_27.0.yaml -L de
    ```
 
 </Steps>

--- a/src/content/docs/personalization/tailoring-rules.mdx
+++ b/src/content/docs/personalization/tailoring-rules.mdx
@@ -66,7 +66,7 @@ Tailoring lets you create a customized baseline by choosing which rules to inclu
 
    | Output | Location |
    |:-------|:---------|
-   | Tailored baseline | `custom/baselines/MyOrgs_Benchmark_macos_26.0.yaml` |
+   | Tailored baseline | `custom/baselines/MyOrgs_Benchmark_macos_27.0.yaml` |
    | Custom ODV rules | `custom/rules/*.yaml` |
 
 </Steps>
@@ -141,7 +141,7 @@ The `main` branch is now used for **mSCP 2.0** and will generate content using t
 
 
 ```bash
-./mscp.py guidance custom/baselines/MyOrgs_Benchmark_macos_26.0.yaml -A
+./mscp.py guidance custom/baselines/MyOrgs_Benchmark_macos_27.0.yaml -A
 ```
 
   </TabItem>

--- a/src/content/docs/repository/rule-file-layout.mdx
+++ b/src/content/docs/repository/rule-file-layout.mdx
@@ -98,12 +98,14 @@ References are nested by source organization:
 references:
   nist:
     cce:
+      macos_27: [CCE-97006-1]
       macos_26: [CCE-95164-0]
       macos_15: [CCE-94164-1]
     800-53r5: [AC-3, CM-5, SI-7]
     800-171r3: [03.01.02, 03.04.05]
   disa:
     disa_stig:
+      macos_27: [APPL-27-002064]
       macos_26: [APPL-26-002064]
       macos_15: [APPL-15-002064]
     srg: [SRG-OS-000480-GPOS-00227]
@@ -155,16 +157,16 @@ discussion: |
 references:
   nist:
     cce:
+      macos_27: [CCE-97006-1]
       macos_26: [CCE-95164-0]
       macos_15: [CCE-94164-1]
-      macos_14: [CCE-92764-0]
     800-53r5: [AC-3, CM-5, SC-34, SI-7]
     800-171r3: [03.01.02, 03.04.05]
   disa:
     disa_stig:
+      macos_27: [APPL-27-002064]
       macos_26: [APPL-26-002064]
       macos_15: [APPL-15-002064]
-      macos_14: [APPL-14-002064]
 tags:
   - 800-53r5_moderate
   - 800-53r5_high
@@ -172,6 +174,12 @@ tags:
   - cnssi-1253_moderate
 platforms:
   macOS:
+    '27.0':
+      benchmarks:
+        - name: cis_lvl1
+        - name: cis_lvl2
+        - name: disa_stig
+          severity: medium
     '26.0':
       benchmarks:
         - name: cis_lvl1

--- a/src/content/docs/repository/script-arguments-list.mdx
+++ b/src/content/docs/repository/script-arguments-list.mdx
@@ -43,7 +43,7 @@ Generates documentation, configuration profiles, compliance scripts, and DDM com
 | `--dark` | Dark mode output |
 
 <Aside type="tip">
-Common usage: `./mscp.py guidance custom/baselines/800-53r5_moderate_macos_26.0.yaml -A`
+Common usage: `./mscp.py guidance custom/baselines/800-53r5_moderate_macos_27.0.yaml -A`
 </Aside>
 
 ---

--- a/src/content/docs/welcome/getting-started.mdx
+++ b/src/content/docs/welcome/getting-started.mdx
@@ -88,11 +88,11 @@ Decide which version to set up with, then follow the steps below.
    ```bash
    # Create a baseline
    ./mscp.py baseline -k cis_lvl1
-   # Output: Generated new baseline file: config/custom/baselines/cis_lvl1_macos_26.0.yaml
+   # Output: Generated new baseline file: config/custom/baselines/cis_lvl1_macos_27.0.yaml
 
    # Generate guidance with all outputs
-   ./mscp.py guidance custom/baselines/cis_lvl1_macos_26.0.yaml -A
-   # Output: MSCP DOCUMENT GENERATION COMPLETE! All documents in: /build/cis_lvl1_macos_26.0/
+   ./mscp.py guidance custom/baselines/cis_lvl1_macos_27.0.yaml -A
+   # Output: MSCP DOCUMENT GENERATION COMPLETE! All documents in: /build/cis_lvl1_macos_27.0/
    ```
 
 </Steps>
@@ -138,7 +138,7 @@ dependency, so there is nothing extra to set up.
    ./mscp.py baseline -k cis_lvl1
 
    # Generate guidance with all outputs
-   ./mscp.py guidance custom/baselines/cis_lvl1_macos_26.0.yaml -A
+   ./mscp.py guidance custom/baselines/cis_lvl1_macos_27.0.yaml -A
 
    # When done, deactivate the virtual environment
    deactivate

--- a/src/content/docs/welcome/quick-guide.mdx
+++ b/src/content/docs/welcome/quick-guide.mdx
@@ -137,7 +137,7 @@ Prefer to install manually with Python? See the <a href={`${base}welcome/getting
    ```bash
    # Example: Generate CIS Level 1 baseline
    ./mscp.py baseline -k cis_lvl1
-   # Output: Generated new baseline file: config/custom/baselines/cis_lvl1_macos_26.0.yaml
+   # Output: Generated new baseline file: config/custom/baselines/cis_lvl1_macos_27.0.yaml
    ```
 
 4. **Generate Outputs**
@@ -157,8 +157,8 @@ Prefer to install manually with Python? See the <a href={`${base}welcome/getting
 
    **Example — Generate all outputs:**
    ```bash
-   ./mscp.py guidance custom/baselines/cis_lvl1_macos_26.0.yaml -A
-   # Output: MSCP DOCUMENT GENERATION COMPLETE! All documents in: /build/cis_lvl1_macos_26.0/
+   ./mscp.py guidance custom/baselines/cis_lvl1_macos_27.0.yaml -A
+   # Output: MSCP DOCUMENT GENERATION COMPLETE! All documents in: /build/cis_lvl1_macos_27.0/
    ```
 
 5. **Use Your Files**
@@ -166,11 +166,11 @@ Prefer to install manually with Python? See the <a href={`${base}welcome/getting
    Everything goes to `build/BASELINE_NAME/`:
 
    ```
-   build/cis_lvl1_macos_26.0/
-   ├── cis_lvl1_macos_26.0.adoc
-   ├── cis_lvl1_macos_26.0.html
-   ├── cis_lvl1_macos_26.0.pdf
-   ├── cis_lvl1_macos_26.0_compliance.sh
+   build/cis_lvl1_macos_27.0/
+   ├── cis_lvl1_macos_27.0.adoc
+   ├── cis_lvl1_macos_27.0.html
+   ├── cis_lvl1_macos_27.0.pdf
+   ├── cis_lvl1_macos_27.0_compliance.sh
    ├── mobileconfigs/
    ├── preferences/
    ├── activations/
@@ -190,7 +190,7 @@ The script must run in **zsh** (default on macOS). Using `bash` or `sh` will cau
 
 **Interactive mode:**
 ```zsh
-sudo ./build/cis_lvl1_macos_26.0/cis_lvl1_macos_26.0_compliance.sh
+sudo ./build/cis_lvl1_macos_27.0/cis_lvl1_macos_27.0_compliance.sh
 ```
 
 **Automated mode:**
@@ -210,10 +210,10 @@ sudo ./build/cis_lvl1_macos_26.0/cis_lvl1_macos_26.0_compliance.sh
 
 ```zsh
 # Quick check
-sudo ./build/cis_lvl1_macos_26.0/cis_lvl1_macos_26.0_compliance.sh --check
+sudo ./build/cis_lvl1_macos_27.0/cis_lvl1_macos_27.0_compliance.sh --check
 
 # Full remediation
-sudo ./build/cis_lvl1_macos_26.0/cis_lvl1_macos_26.0_compliance.sh --cfc --quiet=2
+sudo ./build/cis_lvl1_macos_27.0/cis_lvl1_macos_27.0_compliance.sh --cfc --quiet=2
 ```
 
 ---
@@ -268,20 +268,20 @@ sudo ./build/cis_lvl1_macos_26.0/cis_lvl1_macos_26.0_compliance.sh --cfc --quiet
 **Compliance Check** — Scan a Mac for compliance issues:
 ```bash
 ./mscp.py baseline -k 800-53r5_moderate
-./mscp.py guidance custom/baselines/800-53r5_moderate_macos_26.0.yaml -s
-sudo ./build/800-53r5_moderate_macos_26.0/800-53r5_moderate_macos_26.0_compliance.sh --check
+./mscp.py guidance custom/baselines/800-53r5_moderate_macos_27.0.yaml -s
+sudo ./build/800-53r5_moderate_macos_27.0/800-53r5_moderate_macos_27.0_compliance.sh --check
 ```
 
 **MDM Deployment Package** — Generate profiles and DDM for device management:
 ```bash
 ./mscp.py baseline -k DISA-STIG
-./mscp.py guidance custom/baselines/DISA-STIG_macos_26.0.yaml -p -d -s
+./mscp.py guidance custom/baselines/DISA-STIG_macos_27.0.yaml -p -d -s
 ```
 
 **Full Documentation Set** — Create all outputs for documentation and audit:
 ```bash
 ./mscp.py baseline -k cis_lvl2
-./mscp.py guidance custom/baselines/cis_lvl2_macos_26.0.yaml -A
+./mscp.py guidance custom/baselines/cis_lvl2_macos_27.0.yaml -A
 ```
 
   </TabItem>


### PR DESCRIPTION
## macOS 27 Support

With macOS 27 added and macOS 14 dropped in `release_27.0`, the docs were updated to match the versions mSCP 2.0 actually supports (27.0, 26.0, 15.0).

### Version Updates
- Replaced `macos_14` with `macos_27` in the rule reference examples, using the
  real CCE and STIG IDs from the rules on `dev_27`
- Added a `'27.0'` entry to the `platforms:` examples
- Updated "configs for macOS 14, 15, 26+" to "configs for macOS 15, 26, and 27"
- Bumped **63** example baselines from `macos_26.0` to `macos_27.0`, matching the
  new `--os_version` default

### Left Unchanged
- The macOS 14 DDM requirement and the macOS 14 STIG document link — both still accurate
- The mSCP 1.0 per-version branch notices (`sequoia`, `sonoma`, `ventura`, etc.)

## Landing Page

- Replaced the "mSCP 2.0 Has Arrived" promo with one announcing macOS 27 support
- Removed the mSCP Branches table — 2.0 ships a single unified branch

## Release Notes Rendering

The Latest Release box printed the GitHub release body as raw text, so headings, bullets, and bold showed as literal Markdown and every PR link rendered as a full URL.

- Added a Markdown renderer to `github-latest-release.js` covering headings, lists,
  bold/italic/code, code blocks, links, and `@mentions` — no new dependencies
- Repo links now shorten like GitHub's own renderer (`…/pull/751` → `#751`)
- Release content is HTML-escaped before rendering
